### PR TITLE
Implement SCRAM SHA-256 Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 authenticator/authenticator
 main
 
+ssl/*.key
+ssl/*.crt
+ssl/*.srl
+ssl/*.csr
+
 # Prerequisites
 *.d
 

--- a/authenticator/authenticator.go
+++ b/authenticator/authenticator.go
@@ -136,12 +136,12 @@ func (a *Authenticator) getCreds(identity vaultKey) (string, error) {
 func newVault() map[vaultKey]string {
 	creds := make(map[vaultKey]string)
 	// for dev purposes: read credentials from a local file
-	type secret struct {
+	type secrets []struct {
 		Dbhost   string `yaml:"dbhost"`
 		Dbuser   string `yaml:"dbuser"`
 		Password string `yaml:"password"`
 	}
-	var devCreds secret
+	var devCreds secrets
 	yamlFile, err := ioutil.ReadFile("secrets.yaml")
 	if err != nil {
 		log.Errorf("yamlFile.Get err #%v ", err)
@@ -150,8 +150,11 @@ func newVault() map[vaultKey]string {
 	if err != nil {
 		log.Errorf("Unmarshal: #%v ", err)
 	}
-	key := vaultKey{"arn:aws:iam::403019568400:role/dev", devCreds.Dbhost, devCreds.Dbuser}
-	creds[key] = devCreds.Password
+	for _, cred := range devCreds {
+		key := vaultKey{"arn:aws:iam::403019568400:role/dev", cred.Dbhost, cred.Dbuser}
+		creds[key] = cred.Password
+		log.Debugf("added dev credential for host %s", cred.Dbhost)
+	}
 	return creds
 }
 

--- a/authenticator/authenticator.go
+++ b/authenticator/authenticator.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"golang.org/x/crypto/pbkdf2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v2"
@@ -95,13 +98,13 @@ func verifyService(claimed_iam_arn, signed_get_caller_identity string) error {
 	}
 }
 
-func (a *Authenticator) GetPGMD5Hash(ctx context.Context, req *pb.PGMD5HashRequest) (*pb.PGMD5HashResponse, error) {
+func (a *Authenticator) GetPGMD5Hash(ctx context.Context, req *pb.PGMD5HashRequest) (*pb.PGMD5Response, error) {
 	a.counter++
 
 	claimed_iam_arn := req.GetClaimedIamArn()
 	dbhost := req.GetDbhost()
 	dbuser := req.GetDbuser()
-	log.Printf("received GetDBHash request with claimed_iam_arn: %s\n", claimed_iam_arn)
+	log.Printf("received GetPGMD5Hash request with claimed_iam_arn: %s\n", claimed_iam_arn)
 	err := verifyService(claimed_iam_arn, req.GetSignedGetCallerIdentity())
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, err.Error())
@@ -121,7 +124,42 @@ func (a *Authenticator) GetPGMD5Hash(ctx context.Context, req *pb.PGMD5HashReque
 		return nil, status.Errorf(codes.InvalidArgument, msg)
 	}
 
-	return &pb.PGMD5HashResponse{Hash: computePGMD5(dbuser, password, salt)}, nil
+	return &pb.PGMD5Response{Hash: computePGMD5(dbuser, password, salt)}, nil
+}
+
+func (a *Authenticator) GetPGSHA256Hash(ctx context.Context, req *pb.PGSHA256HashRequest) (*pb.PGSHA256Response, error) {
+	a.counter++
+
+	claimed_iam_arn := req.GetClaimedIamArn()
+	dbhost := req.GetDbhost()
+	dbuser := req.GetDbuser()
+	log.Printf("received GetPGSHA256Hash request with claimed_iam_arn: %s\n", claimed_iam_arn)
+	err := verifyService(claimed_iam_arn, req.GetSignedGetCallerIdentity())
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, err.Error())
+	}
+
+	password, err := a.getCreds(vaultKey{claimed_iam_arn, dbhost, dbuser})
+	if err != nil {
+		log.Error(err)
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+
+	salt := req.GetSalt()
+
+	if len(salt) == 0 {
+		msg := fmt.Sprintf("salt not provided")
+		log.Error(msg)
+		return nil, status.Errorf(codes.InvalidArgument, msg)
+	}
+	iterations := int(req.GetIterations())
+	spassword, err := computePGSHA256(password, salt, iterations)
+	if err != nil {
+		msg := fmt.Sprintf("Could not compute hash %s", err)
+		log.Error(msg)
+		return nil, status.Errorf(codes.InvalidArgument, msg)
+	}
+	return &pb.PGSHA256Response{Spassword: spassword}, nil
 }
 
 func (a *Authenticator) getCreds(identity vaultKey) (string, error) {
@@ -170,4 +208,13 @@ func computePGMD5(user, password string, salt []byte) string {
 	first_hash := computeMD5(password, []byte(user))
 	second_hash := computeMD5(first_hash, salt)
 	return second_hash
+}
+
+func computePGSHA256(password string, salt []byte, iterations int) ([]byte, error) {
+	s, err := base64.StdEncoding.DecodeString(string(salt))
+	if err != nil {
+		return nil, fmt.Errorf("Bad salt %s", err)
+	}
+	dk := pbkdf2.Key([]byte(password), s, iterations, 32, sha256.New)
+	return dk, nil
 }

--- a/authenticator/go.mod
+++ b/authenticator/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/golang/protobuf v1.3.3
 	github.com/sirupsen/logrus v1.6.0
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	google.golang.org/grpc v1.29.1
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/authenticator/go.sum
+++ b/authenticator/go.sum
@@ -23,6 +23,7 @@ github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/authenticator/protos/authenticator.pb.go
+++ b/authenticator/protos/authenticator.pb.go
@@ -95,71 +95,196 @@ func (m *PGMD5HashRequest) GetSalt() []byte {
 	return nil
 }
 
-type PGMD5HashResponse struct {
+type PGSHA256HashRequest struct {
+	SignedGetCallerIdentity string   `protobuf:"bytes,1,opt,name=signed_get_caller_identity,json=signedGetCallerIdentity,proto3" json:"signed_get_caller_identity,omitempty"`
+	ClaimedIamArn           string   `protobuf:"bytes,2,opt,name=claimed_iam_arn,json=claimedIamArn,proto3" json:"claimed_iam_arn,omitempty"`
+	Dbhost                  string   `protobuf:"bytes,3,opt,name=dbhost,proto3" json:"dbhost,omitempty"`
+	Dbuser                  string   `protobuf:"bytes,4,opt,name=dbuser,proto3" json:"dbuser,omitempty"`
+	Salt                    []byte   `protobuf:"bytes,5,opt,name=salt,proto3" json:"salt,omitempty"`
+	Iterations              uint32   `protobuf:"varint,6,opt,name=iterations,proto3" json:"iterations,omitempty"`
+	XXX_NoUnkeyedLiteral    struct{} `json:"-"`
+	XXX_unrecognized        []byte   `json:"-"`
+	XXX_sizecache           int32    `json:"-"`
+}
+
+func (m *PGSHA256HashRequest) Reset()         { *m = PGSHA256HashRequest{} }
+func (m *PGSHA256HashRequest) String() string { return proto.CompactTextString(m) }
+func (*PGSHA256HashRequest) ProtoMessage()    {}
+func (*PGSHA256HashRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_e86ec39f7c35dea3, []int{1}
+}
+
+func (m *PGSHA256HashRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PGSHA256HashRequest.Unmarshal(m, b)
+}
+func (m *PGSHA256HashRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PGSHA256HashRequest.Marshal(b, m, deterministic)
+}
+func (m *PGSHA256HashRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PGSHA256HashRequest.Merge(m, src)
+}
+func (m *PGSHA256HashRequest) XXX_Size() int {
+	return xxx_messageInfo_PGSHA256HashRequest.Size(m)
+}
+func (m *PGSHA256HashRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_PGSHA256HashRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PGSHA256HashRequest proto.InternalMessageInfo
+
+func (m *PGSHA256HashRequest) GetSignedGetCallerIdentity() string {
+	if m != nil {
+		return m.SignedGetCallerIdentity
+	}
+	return ""
+}
+
+func (m *PGSHA256HashRequest) GetClaimedIamArn() string {
+	if m != nil {
+		return m.ClaimedIamArn
+	}
+	return ""
+}
+
+func (m *PGSHA256HashRequest) GetDbhost() string {
+	if m != nil {
+		return m.Dbhost
+	}
+	return ""
+}
+
+func (m *PGSHA256HashRequest) GetDbuser() string {
+	if m != nil {
+		return m.Dbuser
+	}
+	return ""
+}
+
+func (m *PGSHA256HashRequest) GetSalt() []byte {
+	if m != nil {
+		return m.Salt
+	}
+	return nil
+}
+
+func (m *PGSHA256HashRequest) GetIterations() uint32 {
+	if m != nil {
+		return m.Iterations
+	}
+	return 0
+}
+
+type PGMD5Response struct {
 	Hash                 string   `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *PGMD5HashResponse) Reset()         { *m = PGMD5HashResponse{} }
-func (m *PGMD5HashResponse) String() string { return proto.CompactTextString(m) }
-func (*PGMD5HashResponse) ProtoMessage()    {}
-func (*PGMD5HashResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_e86ec39f7c35dea3, []int{1}
+func (m *PGMD5Response) Reset()         { *m = PGMD5Response{} }
+func (m *PGMD5Response) String() string { return proto.CompactTextString(m) }
+func (*PGMD5Response) ProtoMessage()    {}
+func (*PGMD5Response) Descriptor() ([]byte, []int) {
+	return fileDescriptor_e86ec39f7c35dea3, []int{2}
 }
 
-func (m *PGMD5HashResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_PGMD5HashResponse.Unmarshal(m, b)
+func (m *PGMD5Response) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PGMD5Response.Unmarshal(m, b)
 }
-func (m *PGMD5HashResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_PGMD5HashResponse.Marshal(b, m, deterministic)
+func (m *PGMD5Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PGMD5Response.Marshal(b, m, deterministic)
 }
-func (m *PGMD5HashResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PGMD5HashResponse.Merge(m, src)
+func (m *PGMD5Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PGMD5Response.Merge(m, src)
 }
-func (m *PGMD5HashResponse) XXX_Size() int {
-	return xxx_messageInfo_PGMD5HashResponse.Size(m)
+func (m *PGMD5Response) XXX_Size() int {
+	return xxx_messageInfo_PGMD5Response.Size(m)
 }
-func (m *PGMD5HashResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_PGMD5HashResponse.DiscardUnknown(m)
+func (m *PGMD5Response) XXX_DiscardUnknown() {
+	xxx_messageInfo_PGMD5Response.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_PGMD5HashResponse proto.InternalMessageInfo
+var xxx_messageInfo_PGMD5Response proto.InternalMessageInfo
 
-func (m *PGMD5HashResponse) GetHash() string {
+func (m *PGMD5Response) GetHash() string {
 	if m != nil {
 		return m.Hash
 	}
 	return ""
 }
 
+type PGSHA256Response struct {
+	Spassword            []byte   `protobuf:"bytes,1,opt,name=spassword,proto3" json:"spassword,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PGSHA256Response) Reset()         { *m = PGSHA256Response{} }
+func (m *PGSHA256Response) String() string { return proto.CompactTextString(m) }
+func (*PGSHA256Response) ProtoMessage()    {}
+func (*PGSHA256Response) Descriptor() ([]byte, []int) {
+	return fileDescriptor_e86ec39f7c35dea3, []int{3}
+}
+
+func (m *PGSHA256Response) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PGSHA256Response.Unmarshal(m, b)
+}
+func (m *PGSHA256Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PGSHA256Response.Marshal(b, m, deterministic)
+}
+func (m *PGSHA256Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PGSHA256Response.Merge(m, src)
+}
+func (m *PGSHA256Response) XXX_Size() int {
+	return xxx_messageInfo_PGSHA256Response.Size(m)
+}
+func (m *PGSHA256Response) XXX_DiscardUnknown() {
+	xxx_messageInfo_PGSHA256Response.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PGSHA256Response proto.InternalMessageInfo
+
+func (m *PGSHA256Response) GetSpassword() []byte {
+	if m != nil {
+		return m.Spassword
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*PGMD5HashRequest)(nil), "approzium.authenticator.protos.PGMD5HashRequest")
-	proto.RegisterType((*PGMD5HashResponse)(nil), "approzium.authenticator.protos.PGMD5HashResponse")
+	proto.RegisterType((*PGSHA256HashRequest)(nil), "approzium.authenticator.protos.PGSHA256HashRequest")
+	proto.RegisterType((*PGMD5Response)(nil), "approzium.authenticator.protos.PGMD5Response")
+	proto.RegisterType((*PGSHA256Response)(nil), "approzium.authenticator.protos.PGSHA256Response")
 }
 
 func init() { proto.RegisterFile("authenticator.proto", fileDescriptor_e86ec39f7c35dea3) }
 
 var fileDescriptor_e86ec39f7c35dea3 = []byte{
-	// 265 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x90, 0x4f, 0x4b, 0xf3, 0x40,
-	0x10, 0xc6, 0xdf, 0xbc, 0xd6, 0x82, 0x4b, 0x8b, 0xba, 0x82, 0x86, 0x1e, 0xa4, 0xe4, 0xa0, 0x3d,
-	0x05, 0xff, 0xe0, 0xc9, 0x53, 0x51, 0x88, 0x3d, 0x08, 0x92, 0x2f, 0x10, 0xa6, 0xc9, 0xd0, 0x5d,
-	0x48, 0x76, 0xe3, 0xce, 0xec, 0x41, 0x3f, 0x80, 0x5f, 0xca, 0x2f, 0x27, 0xd9, 0x44, 0x29, 0x22,
-	0x82, 0xb7, 0x99, 0xe7, 0x37, 0x0f, 0x3c, 0xf3, 0x88, 0x23, 0xf0, 0xac, 0xd0, 0xb0, 0x2e, 0x81,
-	0xad, 0x4b, 0x5b, 0x67, 0xd9, 0xca, 0x53, 0x68, 0x5b, 0x67, 0x5f, 0xb5, 0x6f, 0xd2, 0x1f, 0x30,
-	0x25, 0xef, 0x91, 0x38, 0x78, 0xca, 0x1e, 0xef, 0x6f, 0x1e, 0x80, 0x54, 0x8e, 0xcf, 0x1e, 0x89,
-	0xe5, 0xad, 0x98, 0x91, 0xde, 0x18, 0xac, 0x8a, 0x0d, 0x72, 0x51, 0x42, 0x5d, 0xa3, 0x2b, 0x74,
-	0xd5, 0x99, 0xf9, 0x25, 0x8e, 0xe6, 0xd1, 0x62, 0x2f, 0x3f, 0xe9, 0x2f, 0x32, 0xe4, 0xbb, 0xc0,
-	0x57, 0x03, 0x96, 0x67, 0x62, 0xbf, 0xac, 0x41, 0x37, 0x58, 0x15, 0x1a, 0x9a, 0x02, 0x9c, 0x89,
-	0xff, 0x07, 0xc7, 0x74, 0x90, 0x57, 0xd0, 0x2c, 0x9d, 0x91, 0xc7, 0x62, 0x5c, 0xad, 0x95, 0x25,
-	0x8e, 0x77, 0x02, 0x1e, 0xb6, 0x5e, 0xf7, 0x84, 0x2e, 0x1e, 0x7d, 0xea, 0xdd, 0x26, 0xa5, 0x18,
-	0x11, 0xd4, 0x1c, 0xef, 0xce, 0xa3, 0xc5, 0x24, 0x0f, 0x73, 0x72, 0x2e, 0x0e, 0xb7, 0xc2, 0x53,
-	0x6b, 0x0d, 0x61, 0x77, 0xa8, 0x80, 0xd4, 0x90, 0x33, 0xcc, 0x57, 0x6f, 0x91, 0x98, 0x2e, 0xb7,
-	0xff, 0x97, 0x5e, 0x4c, 0x32, 0xe4, 0x2f, 0xb7, 0xbc, 0x48, 0x7f, 0x6f, 0x2a, 0xfd, 0xde, 0xd2,
-	0xec, 0xf2, 0x0f, 0x8e, 0x3e, 0x5a, 0xf2, 0x6f, 0x3d, 0x0e, 0xec, 0xfa, 0x23, 0x00, 0x00, 0xff,
-	0xff, 0xa2, 0x9d, 0x62, 0x00, 0xad, 0x01, 0x00, 0x00,
+	// 344 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xd4, 0x52, 0x41, 0x6b, 0xf2, 0x40,
+	0x10, 0xfd, 0xf6, 0xab, 0x15, 0x1c, 0x0c, 0x96, 0x15, 0xda, 0x20, 0x45, 0x24, 0x85, 0xe2, 0xa5,
+	0x41, 0x14, 0x7b, 0xe9, 0x49, 0x5a, 0x88, 0x1e, 0x0a, 0x92, 0xfe, 0x80, 0xb0, 0x9a, 0xc5, 0x2c,
+	0x24, 0xd9, 0xb8, 0xb3, 0xa1, 0xd4, 0xbf, 0xd6, 0xff, 0xd2, 0x9f, 0x52, 0x4a, 0xd6, 0x68, 0xa4,
+	0x2d, 0xad, 0xd7, 0xde, 0x76, 0xde, 0x9b, 0x37, 0x93, 0xc9, 0x7b, 0xd0, 0x66, 0xb9, 0x8e, 0x78,
+	0xaa, 0xc5, 0x92, 0x69, 0xa9, 0xdc, 0x4c, 0x49, 0x2d, 0x69, 0x97, 0x65, 0x99, 0x92, 0x1b, 0x91,
+	0x27, 0xee, 0x37, 0x34, 0x3a, 0xaf, 0x04, 0xce, 0xe6, 0xde, 0xe3, 0xc3, 0x78, 0xca, 0x30, 0xf2,
+	0xf9, 0x3a, 0xe7, 0xa8, 0xe9, 0x1d, 0x74, 0x50, 0xac, 0x52, 0x1e, 0x06, 0x2b, 0xae, 0x83, 0x25,
+	0x8b, 0x63, 0xae, 0x02, 0x11, 0x16, 0x62, 0xfd, 0x62, 0x93, 0x1e, 0xe9, 0x37, 0xfc, 0x8b, 0x6d,
+	0x87, 0xc7, 0xf5, 0xbd, 0xe1, 0x67, 0x25, 0x4d, 0xaf, 0xa1, 0xb5, 0x8c, 0x99, 0x48, 0x78, 0x18,
+	0x08, 0x96, 0x04, 0x4c, 0xa5, 0xf6, 0x7f, 0xa3, 0xb0, 0x4a, 0x78, 0xc6, 0x92, 0x89, 0x4a, 0xe9,
+	0x39, 0xd4, 0xc3, 0x45, 0x24, 0x51, 0xdb, 0x27, 0x86, 0x2e, 0xab, 0x2d, 0x9e, 0x23, 0x57, 0x76,
+	0x6d, 0x87, 0x17, 0x15, 0xa5, 0x50, 0x43, 0x16, 0x6b, 0xfb, 0xb4, 0x47, 0xfa, 0x4d, 0xdf, 0xbc,
+	0x9d, 0x37, 0x02, 0xed, 0xb9, 0xf7, 0x34, 0x9d, 0x0c, 0xc7, 0xb7, 0x7f, 0xf1, 0x00, 0xda, 0x05,
+	0x10, 0x9a, 0x2b, 0xa6, 0x85, 0x4c, 0xd1, 0xae, 0xf7, 0x48, 0xdf, 0xf2, 0x0f, 0x10, 0xe7, 0x0a,
+	0x2c, 0xe3, 0x8e, 0xcf, 0x31, 0x93, 0x29, 0xf2, 0x62, 0x48, 0xc4, 0x30, 0x2a, 0x6f, 0x30, 0x6f,
+	0x67, 0x50, 0x58, 0xb8, 0xfd, 0x09, 0xfb, 0xbe, 0x4b, 0x68, 0x60, 0xc6, 0x10, 0x9f, 0xa5, 0x0a,
+	0x4d, 0x73, 0xd3, 0xaf, 0x80, 0xe1, 0x3b, 0x01, 0x6b, 0x72, 0x18, 0x07, 0xba, 0x86, 0xa6, 0xc7,
+	0xf5, 0x3e, 0x09, 0x74, 0xe0, 0xfe, 0x1c, 0x1c, 0xf7, 0x73, 0x68, 0x3a, 0x37, 0x47, 0x29, 0x76,
+	0x1f, 0xe8, 0xfc, 0xa3, 0x1b, 0x68, 0x99, 0x95, 0x95, 0x7d, 0x74, 0xf4, 0xfb, 0x8c, 0x2f, 0x66,
+	0x77, 0x06, 0xc7, 0x8a, 0xaa, 0xdd, 0x8b, 0xba, 0xa1, 0x46, 0x1f, 0x01, 0x00, 0x00, 0xff, 0xff,
+	0xc0, 0xe8, 0x82, 0x62, 0x34, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -174,7 +299,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type AuthenticatorClient interface {
-	GetPGMD5Hash(ctx context.Context, in *PGMD5HashRequest, opts ...grpc.CallOption) (*PGMD5HashResponse, error)
+	GetPGMD5Hash(ctx context.Context, in *PGMD5HashRequest, opts ...grpc.CallOption) (*PGMD5Response, error)
+	GetPGSHA256Hash(ctx context.Context, in *PGSHA256HashRequest, opts ...grpc.CallOption) (*PGSHA256Response, error)
 }
 
 type authenticatorClient struct {
@@ -185,9 +311,18 @@ func NewAuthenticatorClient(cc *grpc.ClientConn) AuthenticatorClient {
 	return &authenticatorClient{cc}
 }
 
-func (c *authenticatorClient) GetPGMD5Hash(ctx context.Context, in *PGMD5HashRequest, opts ...grpc.CallOption) (*PGMD5HashResponse, error) {
-	out := new(PGMD5HashResponse)
+func (c *authenticatorClient) GetPGMD5Hash(ctx context.Context, in *PGMD5HashRequest, opts ...grpc.CallOption) (*PGMD5Response, error) {
+	out := new(PGMD5Response)
 	err := c.cc.Invoke(ctx, "/approzium.authenticator.protos.Authenticator/GetPGMD5Hash", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *authenticatorClient) GetPGSHA256Hash(ctx context.Context, in *PGSHA256HashRequest, opts ...grpc.CallOption) (*PGSHA256Response, error) {
+	out := new(PGSHA256Response)
+	err := c.cc.Invoke(ctx, "/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -196,15 +331,19 @@ func (c *authenticatorClient) GetPGMD5Hash(ctx context.Context, in *PGMD5HashReq
 
 // AuthenticatorServer is the server API for Authenticator service.
 type AuthenticatorServer interface {
-	GetPGMD5Hash(context.Context, *PGMD5HashRequest) (*PGMD5HashResponse, error)
+	GetPGMD5Hash(context.Context, *PGMD5HashRequest) (*PGMD5Response, error)
+	GetPGSHA256Hash(context.Context, *PGSHA256HashRequest) (*PGSHA256Response, error)
 }
 
 // UnimplementedAuthenticatorServer can be embedded to have forward compatible implementations.
 type UnimplementedAuthenticatorServer struct {
 }
 
-func (*UnimplementedAuthenticatorServer) GetPGMD5Hash(ctx context.Context, req *PGMD5HashRequest) (*PGMD5HashResponse, error) {
+func (*UnimplementedAuthenticatorServer) GetPGMD5Hash(ctx context.Context, req *PGMD5HashRequest) (*PGMD5Response, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetPGMD5Hash not implemented")
+}
+func (*UnimplementedAuthenticatorServer) GetPGSHA256Hash(ctx context.Context, req *PGSHA256HashRequest) (*PGSHA256Response, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetPGSHA256Hash not implemented")
 }
 
 func RegisterAuthenticatorServer(s *grpc.Server, srv AuthenticatorServer) {
@@ -229,6 +368,24 @@ func _Authenticator_GetPGMD5Hash_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Authenticator_GetPGSHA256Hash_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PGSHA256HashRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AuthenticatorServer).GetPGSHA256Hash(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AuthenticatorServer).GetPGSHA256Hash(ctx, req.(*PGSHA256HashRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Authenticator_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "approzium.authenticator.protos.Authenticator",
 	HandlerType: (*AuthenticatorServer)(nil),
@@ -236,6 +393,10 @@ var _Authenticator_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetPGMD5Hash",
 			Handler:    _Authenticator_GetPGMD5Hash_Handler,
+		},
+		{
+			MethodName: "GetPGSHA256Hash",
+			Handler:    _Authenticator_GetPGSHA256Hash_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/authenticator/protos/authenticator.proto
+++ b/authenticator/protos/authenticator.proto
@@ -3,7 +3,8 @@ syntax = "proto3";
 package approzium.authenticator.protos;
 
 service Authenticator {
-        rpc GetPGMD5Hash(PGMD5HashRequest) returns (PGMD5HashResponse) {}
+        rpc GetPGMD5Hash(PGMD5HashRequest) returns (PGMD5Response) {}
+        rpc GetPGSHA256Hash(PGSHA256HashRequest) returns (PGSHA256Response) {}
 }
 
 message PGMD5HashRequest {
@@ -14,6 +15,19 @@ message PGMD5HashRequest {
         bytes salt = 5;
 }
 
-message PGMD5HashResponse {
+message PGSHA256HashRequest {
+        string signed_get_caller_identity = 1;
+        string claimed_iam_arn = 2;
+        string dbhost = 3;
+        string dbuser = 4;
+        bytes salt = 5;
+        uint32 iterations = 6;
+}
+
+message PGMD5Response {
         string hash = 1;
+}
+
+message PGSHA256Response {
+        bytes spassword = 1;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
 version: '3'
 services:
     db:
-        image: postgres
+        build: ssl
+        image: approzium_postgres_ssl
+        command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
         environment:
             - POSTGRES_PASSWORD=password
             - POSTGRES_USER=bob
             - POSTGRES_DB=db
+            - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
+            - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
     authenticator:
         build: authenticator
         image: approzium_authenticator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-    db:
+    dbsha256:
         build: ssl
         image: approzium_postgres_ssl
         command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
@@ -10,6 +10,14 @@ services:
             - POSTGRES_DB=db
             - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
             - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
+    dbmd5:
+        build: ssl
+        image: approzium_postgres_ssl
+        command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
+        environment:
+            - POSTGRES_PASSWORD=password
+            - POSTGRES_USER=bob
+            - POSTGRES_DB=db
     authenticator:
         build: authenticator
         image: approzium_authenticator

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   libpq-dev
 RUN apt-get install -y python3-dev python3-pip
-RUN pip3 install psycopg2 boto3
-# protobuf tools for Python
-RUN pip3 install grpcio grpcio-tools
-WORKDIR /usr/src/approzium/sdk
+# tools for generating Python protobuf files
+RUN pip3 install grpcio-tools
+# install sdk dependencies
+COPY . /usr/src/approzium/sdk
+WORKDIR /usr/src/approzium/sdk/python
+RUN pip3 install -e .

--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   libpq-dev
 RUN apt-get install -y python3-dev python3-pip
+RUN pip3 install --upgrade pip
 # tools for generating Python protobuf files
 RUN pip3 install grpcio-tools
 # install sdk dependencies

--- a/sdk/python/approzium/__init__.py
+++ b/sdk/python/approzium/__init__.py
@@ -3,10 +3,11 @@ import logging
 authenticator_addr = "authenticator:1234"
 iam_role = None
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="[%(filename)s:%(lineno)s - %(funcName)10s() ] %(message)s",
-)
+logger = logging.getLogger(__name__)
+ch = logging.StreamHandler()
+formatter = logging.Formatter("[%(filename)s:%(lineno)s - %(funcName)10s() ] %(message)s")
+ch.setFormatter(formatter)
+logger.addHandler(ch)
 
 
 def set_authenticator(new_authenticator):

--- a/sdk/python/approzium/_psycopg2_ctypes.py
+++ b/sdk/python/approzium/_psycopg2_ctypes.py
@@ -11,10 +11,13 @@ from ctypes import (
 from ctypes.util import find_library
 import socket
 import struct
+import logging
 from sys import getsizeof
 import warnings
 from .socketfromfd import fromfd
 
+
+logger = logging.getLogger(__name__)
 
 libpq = cdll.LoadLibrary("libpq.so.5")
 libssl = cdll.LoadLibrary(find_library("ssl"))
@@ -95,6 +98,7 @@ def read_from_conn(pgconn, nbytes, peek=True, justbytes=False):
             flags = [socket.MSG_PEEK] if peek else []
             sock = fromfd(fd)
             msg = sock.recv(nbytes, *flags)
+    logger.debug(f'got: {msg}')
     return msg
 
 def write_to_conn(pgconn, msg):
@@ -109,6 +113,7 @@ def write_to_conn(pgconn, msg):
             warnings.simplefilter("ignore", ResourceWarning)
             sock = fromfd(pgconn.fileno(), keep_fd=True)
             sock.sendall(msg)
+    logger.debug(f'sent: {msg}')
 
 def set_debug(conn):
     libc = CDLL(find_library('c'))

--- a/sdk/python/approzium/_psycopg2_ctypes.py
+++ b/sdk/python/approzium/_psycopg2_ctypes.py
@@ -1,0 +1,108 @@
+from ctypes import (
+    cdll,
+    create_string_buffer,
+    string_at,
+    memmove,
+    c_void_p,
+    c_int,
+    c_char_p,
+)
+from ctypes.util import find_library
+import struct
+from sys import getsizeof
+import warnings
+from .socketfromfd import fromfd
+
+
+libpq = cdll.LoadLibrary("libpq.so.5")
+libssl = cdll.LoadLibrary(find_library("ssl"))
+
+
+# setup ctypes functions
+# necessary to avoid segfaults when using multiple Python threads
+libpq_PQstatus = libpq.PQstatus
+libpq_PQstatus.argtypes = [c_void_p]
+libpq_PQstatus.restype = c_int
+
+libpq_PQsslInUse = libpq.PQsslInUse
+libpq_PQsslInUse.argtypes = [c_void_p]
+libpq_PQsslInUse.restype = c_int
+
+libpq_PQgetssl = libpq.PQgetssl
+libpq_PQgetssl.argtypes = [c_void_p]
+libpq_PQgetssl.restype = c_void_p
+
+libpq_PQsetnonblocking = libpq.PQsetnonblocking
+libpq_PQsetnonblocking.argtypes = [c_void_p, c_int]
+libpq_PQsetnonblocking.restype = c_int
+
+libssl_SSL_read = libssl.SSL_read
+libssl_SSL_read.argtypes = [c_void_p, c_char_p, c_int]
+libssl_SSL_read.restype = c_int
+
+libssl_SSL_write = libssl.SSL_write
+libssl_SSL_write.argtypes = [c_void_p, c_char_p, c_int]
+libssl_SSL_write.restype = c_int
+
+
+def set_connection_sync(pgconn):
+    mem = bytearray(string_at(id(pgconn), getsizeof(pgconn)))
+    sizeofint = struct.calcsize("@i")
+    sizeoflong = struct.calcsize("@l")
+
+    def addressofint(number, mem=mem):
+        int_bytes = struct.pack("@i", number)
+        return mem.find(int_bytes)
+
+    def intataddress(address):
+        return struct.unpack("@i", mem[address : address + sizeofint])[0]
+
+    # as a check, we check server and protocol version numbers, which succeed
+    # the async value in the psycopg connection struct
+    server_version_addr = addressofint(pgconn.server_version)
+    # check that there is only one match for that value
+    assert (
+        addressofint(pgconn.server_version, mem[server_version_addr + sizeofint :])
+        == -1
+    )
+    protocol_address = server_version_addr - sizeofint
+    protocol_version = intataddress(protocol_address)
+    assert protocol_version == pgconn.protocol_version
+    async_address = protocol_address - sizeoflong
+    async_value = struct.unpack("@l", mem[async_address:protocol_address])[0]
+    assert async_value == pgconn.async
+    new_async_value = struct.pack("@l", 0)
+    memmove(id(pgconn) + async_address, new_async_value, sizeoflong)
+    assert pgconn.async == 0
+    error = libpq_PQsetnonblocking(pgconn.pgconn_ptr, 0)
+    assert error == 0
+
+
+def read_from_conn(pgconn, nbytes):
+    ### XXX: replace with conn.info.ssl_in_use
+    if libpq_PQsslInUse(pgconn.pgconn_ptr):
+        buffer = bytearray(nbytes)
+        c_buffer = create_string_buffer(bytes(buffer), nbytes)
+        ssl_obj = libpq_PQgetssl(pgconn.pgconn_ptr)
+        nread = libssl_SSL_read(ssl_obj, c_buffer, nbytes)
+        bytes = bytearray(c_buffer.raw[:nread])
+    else:
+        fd = pgconn.fileno()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            sock = fromfd(fd)
+            bytes = sock.recv(nbytes)
+            return bytes
+
+def write_to_conn(pgconn, msg):
+    if libpq_PQsslInUse(pgconn.pgconn_ptr):
+        ssl_obj = libpq_PQgetssl(pgconn.pgconn_ptr)
+        c_buffer = create_string_buffer(msg, len(msg))
+        n = libssl_SSL_write(ssl_obj, c_buffer, len(msg))
+        if n != len(msg):
+            raise ValueError("could not send response")
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ResourceWarning)
+            sock = fromfd(pgconn.fileno(), keep_fd=True)
+            sock.sendall(msg)

--- a/sdk/python/approzium/authenticator.py
+++ b/sdk/python/approzium/authenticator.py
@@ -11,20 +11,27 @@ sys.path.append(str(Path(__file__).parent / "protos"))
 import authenticator_pb2_grpc
 import authenticator_pb2
 from .iam import obtain_signed_get_caller_identity
+from . import psycopg2
 
 
-def get_hash(dbhost, dbuser, salt, authenticator):
-    if len(salt) != 4:
-        raise Exception("salt not right size")
+def get_hash(dbhost, dbuser, auth_type, salt, authenticator):
     iam_arn, signed_gci = obtain_signed_get_caller_identity()
-    request = authenticator_pb2.PGMD5HashRequest(
-        signed_get_caller_identity=signed_gci,
-        claimed_iam_arn=iam_arn,
-        dbhost=dbhost,
-        dbuser=dbuser,
-        salt=salt,
-    )
     channel = grpc.insecure_channel(authenticator)
     stub = authenticator_pb2_grpc.AuthenticatorStub(channel)
-    response = stub.GetPGMD5Hash(request)
-    return response.hash
+
+    if auth_type == psycopg2.AUTH_REQ_MD5:
+        if len(salt) != 4:
+            raise Exception("salt not right size")
+        request = authenticator_pb2.PGMD5HashRequest(
+            signed_get_caller_identity=signed_gci,
+            claimed_iam_arn=iam_arn,
+            dbhost=dbhost,
+            dbuser=dbuser,
+            salt=salt,
+        )
+        response = stub.GetPGMD5Hash(request)
+        return response.hash
+    elif auth_type == psycopg2.AUTH_REQ_SASL:
+        auth = salt
+        client_final = auth.create_client_final_message('password')
+        return client_final, auth

--- a/sdk/python/approzium/iam.py
+++ b/sdk/python/approzium/iam.py
@@ -16,4 +16,4 @@ def obtain_signed_get_caller_identity():
     )
     iam_client = iam_session.client("sts")
     presigned_url = iam_client.generate_presigned_url("get_caller_identity", {})
-    return presigned_url
+    return approzium.iam_role, presigned_url

--- a/sdk/python/approzium/misc.py
+++ b/sdk/python/approzium/misc.py
@@ -1,6 +1,61 @@
+import threading
 import struct
+import select
+import socket
+from contextlib import contextmanager
+import os
+import queue
 
 
 def read_int32_from_bytes(bytes, index):
     num = struct.unpack("!i", bytes[index : index + 4])[0]
     return num
+
+
+@contextmanager
+def redirect_socket_nowhere(fileno, feedit=None):
+    void_socket = new_mim_socket(feedit)
+    orig_dest = os.dup(fileno)
+    os.dup2(void_socket.fileno(), fileno)
+    yield
+    os.dup2(orig_dest, fileno)
+
+
+def mim_conn_listen(clientsocket, feedit):
+    child_pid = os.fork()
+    if child_pid != 0:
+        return
+    shouldfeed = False
+    if feedit is not None:
+        print('feedit', feedit)
+        shouldfeed = True
+    while True:
+        rlist, wlist = select.select([clientsocket], [clientsocket], [])[0:2]
+        if clientsocket in rlist:
+            buf = clientsocket.recv(4096)
+            if not buf:
+                break
+        if clientsocket in wlist and shouldfeed:
+            clientsocket.sendall(feedit)
+            shouldfeed = False
+
+def mim_server_listen(new_server_socket, feedit):
+    (clientsocket, address) = new_server_socket.accept()
+    thread = threading.Thread(target=mim_conn_listen, args=(clientsocket, feedit), daemon=True)
+    thread.start()
+    
+def new_mim_socket(feedit):
+    # picking port as 0 allows OS to pick an available port
+    mim_addr = ('', 0)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as new_server_socket:
+        new_server_socket.bind(mim_addr)
+        new_server_socket.listen()
+        mim_addr = new_server_socket.getsockname()  # to get real port num
+        q = queue.Queue()
+        thread = threading.Thread(target=mim_server_listen, args=(new_server_socket, feedit), daemon=True)
+        thread.start()
+        new_conn_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        new_conn_socket.connect(mim_addr)
+        # wait until connection is established
+        thread.join()
+    return new_conn_socket

--- a/sdk/python/approzium/misc.py
+++ b/sdk/python/approzium/misc.py
@@ -1,10 +1,4 @@
-import threading
 import struct
-import select
-import socket
-from contextlib import contextmanager
-import os
-import queue
 import logging
 
 
@@ -13,53 +7,3 @@ logger = logging.getLogger(__name__)
 def read_int32_from_bytes(bytes, index):
     num = struct.unpack("!i", bytes[index : index + 4])[0]
     return num
-
-
-@contextmanager
-def redirect_socket_nowhere(fileno, feedit=None):
-    void_socket = new_mim_socket(feedit)
-    orig_dest = os.dup(fileno)
-    os.dup2(void_socket.fileno(), fileno)
-    logger.debug('redirecting socket')
-    yield
-    os.dup2(orig_dest, fileno)
-    logger.debug('restoring original socket')
-
-
-def mim_conn_listen(clientsocket, feedit):
-    child_pid = os.fork()
-    if child_pid != 0:
-        return
-    logger.debug('listening on connection')
-    while True:
-        rlist, wlist = select.select([clientsocket], [clientsocket], [])[0:2]
-        if clientsocket in rlist:
-            buf = clientsocket.recv(4096)
-            if not buf:
-                break
-            logger.debug(f'got {buf} and ignoring it')
-        if clientsocket in wlist and not feedit is None:
-            logging.debug(f'feeding socket client {feedit}')
-            clientsocket.sendall(feedit)
-            feedit = None
-
-def mim_server_listen(new_server_socket, feedit):
-    (clientsocket, address) = new_server_socket.accept()
-    thread = threading.Thread(target=mim_conn_listen, args=(clientsocket, feedit), daemon=True)
-    thread.start()
-    
-def new_mim_socket(feedit):
-    # picking port as 0 allows OS to pick an available port
-    mim_addr = ('', 0)
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as new_server_socket:
-        new_server_socket.bind(mim_addr)
-        new_server_socket.listen()
-        mim_addr = new_server_socket.getsockname()  # to get real port num
-        q = queue.Queue()
-        thread = threading.Thread(target=mim_server_listen, args=(new_server_socket, feedit), daemon=True)
-        thread.start()
-        new_conn_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        new_conn_socket.connect(mim_addr)
-        # wait until connection is established
-        thread.join()
-    return new_conn_socket

--- a/sdk/python/approzium/pg_scram.pyx
+++ b/sdk/python/approzium/pg_scram.pyx
@@ -1,0 +1,342 @@
+# Copyright (C) 2016-present the asyncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+import base64
+import hashlib
+import hmac
+import re
+import stringprep
+import unicodedata
+
+
+# try to import the secrets library from Python 3.6+ for the
+# cryptographic token generator for generating nonces as part of SCRAM
+# Otherwise fall back on os.urandom
+try:
+    from secrets import token_bytes as generate_token_bytes
+except ImportError:
+    from os import urandom as generate_token_bytes
+
+@cython.final
+cdef class SCRAMAuthentication:
+    """Contains the protocol for generating and a SCRAM hashed password.
+
+    Since PostgreSQL 10, the option to hash passwords using the SCRAM-SHA-256
+    method was added. This module follows the defined protocol, which can be
+    referenced from here:
+
+    https://www.postgresql.org/docs/current/sasl-authentication.html#SASL-SCRAM-SHA-256
+
+    libpq references the following RFCs that it uses for implementation:
+
+        * RFC 5802
+        * RFC 5803
+        * RFC 7677
+
+    The protocol works as such:
+
+    - A client connets to the server. The server requests the client to begin
+    SASL authentication using SCRAM and presents a client with the methods it
+    supports. At present, those are SCRAM-SHA-256, and, on servers that are
+    built with OpenSSL and
+    are PG11+, SCRAM-SHA-256-PLUS (which supports channel binding, more on that
+    below)
+
+    - The client sends a "first message" to the server, where it chooses which
+    method to authenticate with, and sends, along with the method, an indication
+    of channel binding (we disable for now), a nonce, and the username.
+    (Technically, PostgreSQL ignores the username as it already has it from the
+    initical connection, but we add it for completeness)
+
+    - The server responds with a "first message" in which it extends the nonce,
+    as well as a password salt and the number of iterations to hash the password
+    with. The client validates that the new nonce contains the first part of the
+    client's original nonce
+
+    - The client generates a salted password, but does not sent this up to the
+    server. Instead, the client follows the SCRAM algorithm (RFC5802) to
+    generate a proof. This proof is sent aspart of a client "final message" to
+    the server for it to validate.
+
+    - The server validates the proof. If it is valid, the server sends a
+    verification code for the client to verify that the server came to the same
+    proof the client did. PostgreSQL immediately sends an AuthenticationOK
+    response right after a valid negotiation. If the password the client
+    provided was invalid, then authentication fails.
+
+    (The beauty of this is that the salted password is never transmitted over
+    the wire!)
+
+    PostgreSQL 11 added support for the channel binding (i.e.
+    SCRAM-SHA-256-PLUS) but to do some ongoing discussion, there is a conscious
+    decision by several driver authors to not support it as of yet. As such, the
+    channel binding parameter is hard-coded to "n" for now, but can be updated
+    to support other channel binding methos in the future
+    """
+    AUTHENTICATION_METHODS = [b"SCRAM-SHA-256"]
+    DEFAULT_CLIENT_NONCE_BYTES = 24
+    DIGEST = hashlib.sha256
+    REQUIREMENTS_CLIENT_FINAL_MESSAGE = ['client_channel_binding',
+        'server_nonce']
+    REQUIREMENTS_CLIENT_PROOF = ['password_iterations', 'password_salt',
+        'server_first_message', 'server_nonce']
+    SASLPREP_PROHIBITED = (
+        stringprep.in_table_a1, # PostgreSQL treats this as prohibited
+        stringprep.in_table_c12,
+        stringprep.in_table_c21_c22,
+        stringprep.in_table_c3,
+        stringprep.in_table_c4,
+        stringprep.in_table_c5,
+        stringprep.in_table_c6,
+        stringprep.in_table_c7,
+        stringprep.in_table_c8,
+        stringprep.in_table_c9,
+    )
+
+    def __cinit__(self, bytes authentication_method):
+        self.authentication_method = authentication_method
+        self.authorization_message = None
+        # channel binding is turned off for the time being
+        self.client_channel_binding = b"n,,"
+        self.client_first_message_bare = None
+        self.client_nonce = None
+        self.client_proof = None
+        self.password_salt = None
+        # self.password_iterations = None
+        self.server_first_message = None
+        self.server_key = None
+        self.server_nonce = None
+
+    cdef create_client_first_message(self, str username):
+        """Create the initial client message for SCRAM authentication"""
+        cdef:
+            bytes msg
+            bytes client_first_message
+
+        self.client_nonce = \
+            self._generate_client_nonce(self.DEFAULT_CLIENT_NONCE_BYTES)
+        # set the client first message bare here, as it's used in a later step
+        self.client_first_message_bare =  b"n=" + username.encode("utf-8") + \
+            b",r=" + self.client_nonce
+        # put together the full message here
+        msg = bytes()
+        msg += self.authentication_method + b"\0"
+        client_first_message = self.client_channel_binding + \
+            self.client_first_message_bare
+        msg += (len(client_first_message)).to_bytes(4, byteorder='big') + \
+            client_first_message
+        return msg
+
+    cdef create_client_final_message(self, str password):
+        """Create the final client message as part of SCRAM authentication"""
+        cdef:
+            bytes msg
+
+        if any([getattr(self, val) is None for val in
+                self.REQUIREMENTS_CLIENT_FINAL_MESSAGE]):
+            raise Exception(
+                "you need values from server to generate a client proof")
+
+        # normalize the password using the SASLprep algorithm in RFC 4013
+        password = self._normalize_password(password)
+
+        # generate the client proof
+        self.client_proof = self._generate_client_proof(password=password)
+        msg = bytes()
+        msg += b"c=" + base64.b64encode(self.client_channel_binding) + \
+            b",r=" + self.server_nonce + \
+            b",p=" + base64.b64encode(self.client_proof)
+        return msg
+
+    cdef parse_server_first_message(self, bytes server_response):
+        """Parse the response from the first message from the server"""
+        self.server_first_message = server_response
+        try:
+            self.server_nonce = re.search(b'r=([^,]+),',
+                self.server_first_message).group(1)
+        except IndexError:
+            raise Exception("could not get nonce")
+        if not self.server_nonce.startswith(self.client_nonce):
+            raise Exception("invalid nonce")
+        try:
+            self.password_salt = re.search(b's=([^,]+),',
+                self.server_first_message).group(1)
+        except IndexError:
+            raise Exception("could not get salt")
+        try:
+            self.password_iterations = int(re.search(b'i=(\d+),?',
+                self.server_first_message).group(1))
+        except (IndexError, TypeError, ValueError):
+            raise Exception("could not get iterations")
+
+    cdef verify_server_final_message(self, bytes server_final_message):
+        """Verify the final message from the server"""
+        cdef:
+            bytes server_signature
+
+        try:
+            server_signature = re.search(b'v=([^,]+)',
+                server_final_message).group(1)
+        except IndexError:
+            raise Exception("could not get server signature")
+
+        verify_server_signature = hmac.new(self.server_key.digest(),
+            self.authorization_message, self.DIGEST)
+        # validate the server signature against the verifier
+        return server_signature == base64.b64encode(
+            verify_server_signature.digest())
+
+    cdef _bytes_xor(self, bytes a, bytes b):
+        """XOR two bytestrings together"""
+        return bytes(a_i ^ b_i for a_i, b_i in zip(a, b))
+
+    cdef _generate_client_nonce(self, int num_bytes):
+        cdef:
+            bytes token
+
+        token = generate_token_bytes(num_bytes)
+
+        return base64.b64encode(token)
+
+    cdef _generate_client_proof(self, str password):
+        """need to ensure a server response exists, i.e. """
+        cdef:
+            bytes salted_password
+
+        if any([getattr(self, val) is None for val in
+                self.REQUIREMENTS_CLIENT_PROOF]):
+            raise Exception(
+                "you need values from server to generate a client proof")
+        # generate a salt password
+        salted_password = self._generate_salted_password(password,
+            self.password_salt, self.password_iterations)
+        # client key is derived from the salted password
+        client_key = hmac.new(salted_password, b"Client Key", self.DIGEST)
+        # this allows us to compute the stored key that is residing on the server
+        stored_key = self.DIGEST(client_key.digest())
+        # as well as compute the server key
+        self.server_key = hmac.new(salted_password, b"Server Key", self.DIGEST)
+        # build the authorization message that will be used in the
+        # client signature
+        # the "c=" portion is for the channel binding, but this is not
+        # presently implemented
+        self.authorization_message = self.client_first_message_bare + b"," + \
+            self.server_first_message + b",c=" + \
+            base64.b64encode(self.client_channel_binding) + \
+            b",r=" +  self.server_nonce
+        # sign!
+        client_signature = hmac.new(stored_key.digest(),
+            self.authorization_message, self.DIGEST)
+        # and the proof
+        return self._bytes_xor(client_key.digest(), client_signature.digest())
+
+    cdef _generate_salted_password(self, str password, bytes salt, int iterations):
+        """This follows the "Hi" algorithm specified in RFC5802"""
+        cdef:
+            bytes p
+            bytes s
+            bytes u
+
+        # convert the password to a binary string - UTF8 is safe for SASL
+        # (though there are SASLPrep rules)
+        p = password.encode("utf8")
+        # the salt needs to be base64 decoded -- full binary must be used
+        s = base64.b64decode(salt)
+        # the initial signature is the salt with a terminator of a 32-bit string
+        # ending in 1
+        ui = hmac.new(p, s + b'\x00\x00\x00\x01', self.DIGEST)
+        # grab the initial digest
+        u = ui.digest()
+        # for X number of iterations, recompute the HMAC signature against the
+        # password and the latest iteration of the hash, and XOR it with the
+        # previous version
+        for x in range(iterations - 1):
+            ui = hmac.new(p, ui.digest(), hashlib.sha256)
+            # this is a fancy way of XORing two byte strings together
+            u = self._bytes_xor(u, ui.digest())
+        return u
+
+    cdef _normalize_password(self, str original_password):
+        """Normalize the password using the SASLprep from RFC4013"""
+        cdef:
+            str normalized_password
+
+        # Note: Per the PostgreSQL documentation, PostgreSWL does not require
+        # UTF-8 to be used for the password, but will perform SASLprep on the
+        # password regardless.
+        # If the password is not valid UTF-8, PostgreSQL will then **not** use
+        # SASLprep processing.
+        # If the password fails SASLprep, the password should still be sent
+        # See: https://www.postgresql.org/docs/current/sasl-authentication.html
+        # and
+        # https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/common/saslprep.c
+        # using the `pg_saslprep` function
+        normalized_password = original_password
+        # if the original password is an ASCII string or fails to encode as a
+        # UTF-8 string, then no further action is needed
+        try:
+            original_password.encode("ascii")
+        except UnicodeEncodeError:
+            pass
+        else:
+            return original_password
+
+        # Step 1 of SASLPrep: Map. Per the algorithm, we map non-ascii space
+        # characters to ASCII spaces (\x20 or \u0020, but we will use ' ') and
+        # commonly mapped to nothing characters are removed
+        # Table C.1.2 -- non-ASCII spaces
+        # Table B.1 -- "Commonly mapped to nothing"
+        normalized_password = u"".join(
+            [' ' if stringprep.in_table_c12(c) else c
+            for c in normalized_password if not stringprep.in_table_b1(c)])
+
+        # If at this point the password is empty, PostgreSQL uses the original
+        # password
+        if not normalized_password:
+            return original_password
+
+        # Step 2 of SASLPrep: Normalize. Normalize the password using the
+        # Unicode normalization algorithm to NFKC form
+        normalized_password = unicodedata.normalize('NFKC', normalized_password)
+
+        # If the password is not empty, PostgreSQL uses the original password
+        if not normalized_password:
+            return original_password
+
+        # Step 3 of SASLPrep: Prohobited characters. If PostgreSQL detects any
+        # of the prohibited characters in SASLPrep, it will use the original
+        # password
+        # We also include "unassigned code points" in the prohibited character
+        # category as PostgreSQL does the same
+        for c in normalized_password:
+            if any([in_prohibited_table(c) for in_prohibited_table in
+                    self.SASLPREP_PROHIBITED]):
+                return original_password
+
+
+        # Step 4 of SASLPrep: Bi-directional characters. PostgreSQL follows the
+        # rules for bi-directional characters laid on in RFC3454 Sec. 6 which
+        # are:
+        # 1. Characters in RFC 3454 Sec 5.8 are prohibited (C.8)
+        # 2. If a string contains a RandALCat character, it cannot containy any
+        #    LCat character
+        # 3. If the string contains any RandALCat character, an RandALCat
+        #    character must be the first and last character of the string
+        # RandALCat characters are found in table D.1, whereas LCat are in D.2
+        if any([stringprep.in_table_d1(c) for c in normalized_password]):
+            # if the first character or the last character are not in D.1,
+            # return the original password
+            if not (stringprep.in_table_d1(normalized_password[0]) and
+                    stringprep.in_table_d1(normalized_password[-1])):
+                return original_password
+
+            # if any characters are in D.2, use the original password
+            if any([stringprep.in_table_d2(c) for c in normalized_password]):
+                return original_password
+
+        # return the normalized password
+        return normalized_password

--- a/sdk/python/approzium/protos/authenticator_pb2.py
+++ b/sdk/python/approzium/protos/authenticator_pb2.py
@@ -18,7 +18,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='approzium.authenticator.protos',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=b'\n\x13\x61uthenticator.proto\x12\x1e\x61pprozium.authenticator.protos\"}\n\x10PGMD5HashRequest\x12\"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x04 \x01(\t\x12\x0c\n\x04salt\x18\x05 \x01(\x0c\"!\n\x11PGMD5HashResponse\x12\x0c\n\x04hash\x18\x01 \x01(\t2\x86\x01\n\rAuthenticator\x12u\n\x0cGetPGMD5Hash\x12\x30.approzium.authenticator.protos.PGMD5HashRequest\x1a\x31.approzium.authenticator.protos.PGMD5HashResponse\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\x13\x61uthenticator.proto\x12\x1e\x61pprozium.authenticator.protos\"}\n\x10PGMD5HashRequest\x12\"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x04 \x01(\t\x12\x0c\n\x04salt\x18\x05 \x01(\x0c\"\x94\x01\n\x13PGSHA256HashRequest\x12\"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x04 \x01(\t\x12\x0c\n\x04salt\x18\x05 \x01(\x0c\x12\x12\n\niterations\x18\x06 \x01(\r\"\x1d\n\rPGMD5Response\x12\x0c\n\x04hash\x18\x01 \x01(\t\"%\n\x10PGSHA256Response\x12\x11\n\tspassword\x18\x01 \x01(\x0c\x32\xfe\x01\n\rAuthenticator\x12q\n\x0cGetPGMD5Hash\x12\x30.approzium.authenticator.protos.PGMD5HashRequest\x1a-.approzium.authenticator.protos.PGMD5Response\"\x00\x12z\n\x0fGetPGSHA256Hash\x12\x33.approzium.authenticator.protos.PGSHA256HashRequest\x1a\x30.approzium.authenticator.protos.PGSHA256Response\"\x00\x62\x06proto3'
 )
 
 
@@ -83,15 +83,81 @@ _PGMD5HASHREQUEST = _descriptor.Descriptor(
 )
 
 
-_PGMD5HASHRESPONSE = _descriptor.Descriptor(
-  name='PGMD5HashResponse',
-  full_name='approzium.authenticator.protos.PGMD5HashResponse',
+_PGSHA256HASHREQUEST = _descriptor.Descriptor(
+  name='PGSHA256HashRequest',
+  full_name='approzium.authenticator.protos.PGSHA256HashRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='hash', full_name='approzium.authenticator.protos.PGMD5HashResponse.hash', index=0,
+      name='signed_get_caller_identity', full_name='approzium.authenticator.protos.PGSHA256HashRequest.signed_get_caller_identity', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='claimed_iam_arn', full_name='approzium.authenticator.protos.PGSHA256HashRequest.claimed_iam_arn', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='dbhost', full_name='approzium.authenticator.protos.PGSHA256HashRequest.dbhost', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='dbuser', full_name='approzium.authenticator.protos.PGSHA256HashRequest.dbuser', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='salt', full_name='approzium.authenticator.protos.PGSHA256HashRequest.salt', index=4,
+      number=5, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='iterations', full_name='approzium.authenticator.protos.PGSHA256HashRequest.iterations', index=5,
+      number=6, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=183,
+  serialized_end=331,
+)
+
+
+_PGMD5RESPONSE = _descriptor.Descriptor(
+  name='PGMD5Response',
+  full_name='approzium.authenticator.protos.PGMD5Response',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='hash', full_name='approzium.authenticator.protos.PGMD5Response.hash', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -109,12 +175,45 @@ _PGMD5HASHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=182,
-  serialized_end=215,
+  serialized_start=333,
+  serialized_end=362,
+)
+
+
+_PGSHA256RESPONSE = _descriptor.Descriptor(
+  name='PGSHA256Response',
+  full_name='approzium.authenticator.protos.PGSHA256Response',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='spassword', full_name='approzium.authenticator.protos.PGSHA256Response.spassword', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=364,
+  serialized_end=401,
 )
 
 DESCRIPTOR.message_types_by_name['PGMD5HashRequest'] = _PGMD5HASHREQUEST
-DESCRIPTOR.message_types_by_name['PGMD5HashResponse'] = _PGMD5HASHRESPONSE
+DESCRIPTOR.message_types_by_name['PGSHA256HashRequest'] = _PGSHA256HASHREQUEST
+DESCRIPTOR.message_types_by_name['PGMD5Response'] = _PGMD5RESPONSE
+DESCRIPTOR.message_types_by_name['PGSHA256Response'] = _PGSHA256RESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 PGMD5HashRequest = _reflection.GeneratedProtocolMessageType('PGMD5HashRequest', (_message.Message,), {
@@ -124,12 +223,26 @@ PGMD5HashRequest = _reflection.GeneratedProtocolMessageType('PGMD5HashRequest', 
   })
 _sym_db.RegisterMessage(PGMD5HashRequest)
 
-PGMD5HashResponse = _reflection.GeneratedProtocolMessageType('PGMD5HashResponse', (_message.Message,), {
-  'DESCRIPTOR' : _PGMD5HASHRESPONSE,
+PGSHA256HashRequest = _reflection.GeneratedProtocolMessageType('PGSHA256HashRequest', (_message.Message,), {
+  'DESCRIPTOR' : _PGSHA256HASHREQUEST,
   '__module__' : 'authenticator_pb2'
-  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGMD5HashResponse)
+  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGSHA256HashRequest)
   })
-_sym_db.RegisterMessage(PGMD5HashResponse)
+_sym_db.RegisterMessage(PGSHA256HashRequest)
+
+PGMD5Response = _reflection.GeneratedProtocolMessageType('PGMD5Response', (_message.Message,), {
+  'DESCRIPTOR' : _PGMD5RESPONSE,
+  '__module__' : 'authenticator_pb2'
+  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGMD5Response)
+  })
+_sym_db.RegisterMessage(PGMD5Response)
+
+PGSHA256Response = _reflection.GeneratedProtocolMessageType('PGSHA256Response', (_message.Message,), {
+  'DESCRIPTOR' : _PGSHA256RESPONSE,
+  '__module__' : 'authenticator_pb2'
+  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGSHA256Response)
+  })
+_sym_db.RegisterMessage(PGSHA256Response)
 
 
 
@@ -139,8 +252,8 @@ _AUTHENTICATOR = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=218,
-  serialized_end=352,
+  serialized_start=404,
+  serialized_end=658,
   methods=[
   _descriptor.MethodDescriptor(
     name='GetPGMD5Hash',
@@ -148,7 +261,16 @@ _AUTHENTICATOR = _descriptor.ServiceDescriptor(
     index=0,
     containing_service=None,
     input_type=_PGMD5HASHREQUEST,
-    output_type=_PGMD5HASHRESPONSE,
+    output_type=_PGMD5RESPONSE,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='GetPGSHA256Hash',
+    full_name='approzium.authenticator.protos.Authenticator.GetPGSHA256Hash',
+    index=1,
+    containing_service=None,
+    input_type=_PGSHA256HASHREQUEST,
+    output_type=_PGSHA256RESPONSE,
     serialized_options=None,
   ),
 ])

--- a/sdk/python/approzium/protos/authenticator_pb2_grpc.py
+++ b/sdk/python/approzium/protos/authenticator_pb2_grpc.py
@@ -16,7 +16,12 @@ class AuthenticatorStub(object):
         self.GetPGMD5Hash = channel.unary_unary(
                 '/approzium.authenticator.protos.Authenticator/GetPGMD5Hash',
                 request_serializer=authenticator__pb2.PGMD5HashRequest.SerializeToString,
-                response_deserializer=authenticator__pb2.PGMD5HashResponse.FromString,
+                response_deserializer=authenticator__pb2.PGMD5Response.FromString,
+                )
+        self.GetPGSHA256Hash = channel.unary_unary(
+                '/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash',
+                request_serializer=authenticator__pb2.PGSHA256HashRequest.SerializeToString,
+                response_deserializer=authenticator__pb2.PGSHA256Response.FromString,
                 )
 
 
@@ -29,13 +34,24 @@ class AuthenticatorServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def GetPGSHA256Hash(self, request, context):
+        """Missing associated documentation comment in .proto file"""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_AuthenticatorServicer_to_server(servicer, server):
     rpc_method_handlers = {
             'GetPGMD5Hash': grpc.unary_unary_rpc_method_handler(
                     servicer.GetPGMD5Hash,
                     request_deserializer=authenticator__pb2.PGMD5HashRequest.FromString,
-                    response_serializer=authenticator__pb2.PGMD5HashResponse.SerializeToString,
+                    response_serializer=authenticator__pb2.PGMD5Response.SerializeToString,
+            ),
+            'GetPGSHA256Hash': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetPGSHA256Hash,
+                    request_deserializer=authenticator__pb2.PGSHA256HashRequest.FromString,
+                    response_serializer=authenticator__pb2.PGSHA256Response.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -59,6 +75,22 @@ class Authenticator(object):
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/approzium.authenticator.protos.Authenticator/GetPGMD5Hash',
             authenticator__pb2.PGMD5HashRequest.SerializeToString,
-            authenticator__pb2.PGMD5HashResponse.FromString,
+            authenticator__pb2.PGMD5Response.FromString,
+            options, channel_credentials,
+            call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def GetPGSHA256Hash(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash',
+            authenticator__pb2.PGSHA256HashRequest.SerializeToString,
+            authenticator__pb2.PGSHA256Response.FromString,
             options, channel_credentials,
             call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/sdk/python/approzium/psycopg2.py
+++ b/sdk/python/approzium/psycopg2.py
@@ -16,7 +16,7 @@ from ._psycopg2_ctypes import (
     write_to_conn,
 )
 from .authenticator import get_hash
-from .misc import read_int32_from_bytes
+from .misc import read_int32_from_bytes, redirect_socket_nowhere
 import approzium
 
 
@@ -28,18 +28,32 @@ AUTH_REQ_SASL = 10
 pgconnect = psycopg2.connect
 
 
+def _normal_poll(pgconn):
+    '''Poll an Approzium type connection using just the Psycopg2 poll and not
+    our custom poll function.
+    '''
+    super(type(pgconn), pgconn).poll()
 
 def read_salt(pgconn):
     # request many more bytes than necessary. if connection is at the
     # right stage, only the right number of bytes will be received
     NBYTES = 8096
-    challenge = read_from_conn(pgconn, NBYTES)
+    # peek now and only remove data from socket once we are sure that this is
+    # a supported authentication message.
+    challenge = read_from_conn(pgconn, NBYTES, peek=True)
     msg_size = read_int32_from_bytes(challenge, 1)
     auth_type = read_int32_from_bytes(challenge, 5)
     if challenge[0] != ord("R"):
         raise Exception("Authentication message not received")
     if auth_type == AUTH_REQ_MD5 and msg_size == 12:
         salt = challenge[9 : 9 + 4]
+        # remove bytes from socket and feed them to libpq through void socket
+        read_from_conn(pgconn, NBYTES, peek=False)
+        with redirect_socket_nowhere(pgconn.fileno(), feedit=challenge):
+            try:
+                _normal_poll(pgconn)
+            except:
+                pass
         return bytes(salt)
     elif auth_type == AUTH_REQ_SASL and msg_size == 23:
         if challenge[9:22] != b'SCRAM-SHA-256':
@@ -73,7 +87,6 @@ def send_hash(pgconn, hash):
     write_to_conn(pgconn, msg)
 
 
-
 def construct_approzium_conn(base, is_sync):
     if not base:
         base = psycopg2.extensions.connection
@@ -100,11 +113,11 @@ def construct_approzium_conn(base, is_sync):
         def poll(self):
             status = libpq_PQstatus(self.pgconn_ptr)
             if status == self.CONNECTION_AWAITING_RESPONSE and not self._salt:
-                logging.debug("reading salt")
+                logger.debug("reading salt")
                 self._salt = read_salt(self)
                 return psycopg2.extensions.POLL_WRITE
             elif self._salt and not self._hash_sent:
-                logging.debug("sending hash")
+                logger.debug("sending hash")
                 dbhost = self.get_dsn_parameters()["host"]
                 dbuser = self.get_dsn_parameters()["user"]
                 hash = get_hash(
@@ -114,7 +127,7 @@ def construct_approzium_conn(base, is_sync):
                 self._hash_sent = True
                 return psycopg2.extensions.POLL_WRITE
             else:
-                logging.debug("normal poll")
+                logger.debug("normal poll")
                 return super().poll()
 
     return ApproziumConn

--- a/sdk/python/approzium/psycopg2.py
+++ b/sdk/python/approzium/psycopg2.py
@@ -87,7 +87,7 @@ def send_hash(pgconn, auth_type, hash):
         select.select([pgconn.fileno()], [], [])
         resp_type, server_final = read_msg(pgconn)
         if resp_type != b'R':
-            raise Exception('Error received unexpected response', server_first)
+            raise Exception('Error received unexpected response', server_final)
         if not auth.verify_server_final_message(server_final):
             raise Exception('Error bad server signature')
 

--- a/sdk/python/client.py
+++ b/sdk/python/client.py
@@ -1,9 +1,18 @@
 import psycopg2
 from approzium.psycopg2 import connect
 from approzium import set_authenticator, set_iam_role
+import logging
+
+logger = logging.getLogger('approzium')
+logger.setLevel(logging.DEBUG)
 
 
 set_iam_role('arn:aws:iam::accountid:role/rolename')
 set_authenticator('authenticator:1234')
 conn = connect("")
 print('Connection Established')
+
+def test():
+    conn.cursor().execute('SELECT 1')
+
+test()

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
         install_requires=[
             'psycopg2',
             'boto3',
-            'grpcio'
+            'grpcio',
+            'cython'
         ]
 )

--- a/ssl/Dockerfile
+++ b/ssl/Dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:12.3
+LABEL "Product"="PostgreSQL (SSL enabled)"
+COPY server.key /var/lib/postgresql/server.key
+COPY server.crt /var/lib/postgresql/server.crt
+RUN chown postgres /var/lib/postgresql/server.key && \
+    chmod 600 /var/lib/postgresql/server.key

--- a/ssl/aios_gen_cert.sh
+++ b/ssl/aios_gen_cert.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$0")
+LOGGING_PREFIX="gen_cert.sh >> "
+
+PASSKEY=somekey
+
+rm -f ${BASEDIR}/server.crt
+rm -f ${BASEDIR}/server.csr
+rm -f ${BASEDIR}/server.key
+rm -f ${BASEDIR}/rootCA.crt
+rm -f ${BASEDIR}/rootCA.csr
+rm -f ${BASEDIR}/rootCA.key
+rm -f ${BASEDIR}/rootCA.srl
+
+# generate a key for our root CA certificate
+echo "${LOGGING_PREFIX} Generating key for root CA certificate"
+openssl genrsa -des3 -passout pass:${PASSKEY} -out ${BASEDIR}/rootCA.pass.key 2048
+openssl rsa -passin pass:${PASSKEY} -in ${BASEDIR}/rootCA.pass.key -out ${BASEDIR}/rootCA.key
+rm ${BASEDIR}/rootCA.pass.key
+echo
+
+# create and self sign the root CA certificate
+echo
+echo "${LOGGING_PREFIX} Creating self-signed root CA certificate"
+openssl req -x509 -new -nodes -key ${BASEDIR}/rootCA.key -sha256 -days 1024 -out ${BASEDIR}/rootCA.crt -subj "/C=UK/ST=/L=/O=IBM/OU=AIOS/CN=aios-orch-dev-env-CA"
+echo "${LOGGING_PREFIX} Self-signed root CA certificate (${BASEDIR}/rootCA.crt) is:"
+openssl x509 -in ${BASEDIR}/rootCA.crt -text -noout
+echo
+
+# generate a key for our server certificate
+echo 
+echo "${LOGGING_PREFIX} Generating key for server certificate"
+openssl genrsa -des3 -passout pass:${PASSKEY} -out ${BASEDIR}/server.pass.key 2048
+openssl rsa -passin pass:${PASSKEY} -in ${BASEDIR}/server.pass.key -out ${BASEDIR}/server.key
+rm ${BASEDIR}/server.pass.key
+echo
+
+# create a certificate request for our server. This includes a subject alternative name so either aios-localhost, localhost or postgres_ssl can be used to address it
+echo
+echo "${LOGGING_PREFIX} Creating server certificate"
+openssl req -new -key ${BASEDIR}/server.key -out ${BASEDIR}/server.csr -subj "/C=UK/ST=/L=/O=IBM/OU=AIOS/CN=postgres_ssl" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:postgres_ssl,DNS:localhost,DNS:aios-localhost")) 
+echo "${LOGGING_PREFIX} Server certificate signing request (${BASEDIR}/server.csr) is:"
+openssl req -verify -in ${BASEDIR}/server.csr -text -noout
+echo
+
+# use our CA certificate and key to create a signed version of the server certificate
+echo 
+echo "${LOGGING_PREFIX} Signing server certificate using our root CA certificate and key"
+openssl x509 -req -sha256 -days 365 -in ${BASEDIR}/server.csr -CA ${BASEDIR}/rootCA.crt -CAkey ${BASEDIR}/rootCA.key -CAcreateserial -out ${BASEDIR}/server.crt -extensions SAN -extfile <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:postgres_ssl,DNS:localhost,DNS:aios-localhost")) 
+chmod og-rwx ${BASEDIR}/server.key
+echo "${LOGGING_PREFIX} Server certificate signed with our root CA certificate (${BASEDIR}/server.crt) is:"
+openssl x509 -in ${BASEDIR}/server.crt -text -noout
+echo
+
+# done output the base64 encoded version of the root CA certificate which should be added to trust stores
+echo
+echo "${LOGGING_PREFIX} Done. Next time the postgres_ssl docker image is rebuilt the new server certificate (${BASEDIR}/server.crt) will be used."
+echo
+echo "${LOGGING_PREFIX} Use the following CA certificate variables:"
+B64_CA_CERT=`cat ${BASEDIR}/rootCA.crt | base64`
+echo "POSTGRES_SSL_CA_CERT=${B64_CA_CERT}"


### PR DESCRIPTION
Main feature:
- Implement SCRAM SHA-256 authentication on Authenticator and Python SDK sides.
- Implement appropriate module-level logging in Python SDK

Minor features:
- Add SSL support to Postgres docker image (useful for testing)
- Introduce two Postgres services in docker-compose (one that uses MD5, the other uses SHA-256)
- Make Authenticator be able to hold multiple dev credentials (to be able to simultaneously test said databases)
- Refactor SDK Psycopg2 connection code (move low-level functions to _psycopg2_ctypes.py)
- Copy scram implementation file from Asyncpg source code (with modifications to fit our use case)