### PR TITLE
Add check for openssl

### DIFF
--- a/sdk/python/approzium/_psycopg2_ctypes.py
+++ b/sdk/python/approzium/_psycopg2_ctypes.py
@@ -130,3 +130,7 @@ def set_debug(conn):
     libc = CDLL(find_library('c'))
     stdout = c_void_p.in_dll(libc, 'stdout')
     libpq.PQtrace(conn.pgconn_ptr, stdout)
+
+def ensure_compatible_ssl(conn):
+    if conn.info.ssl_attribute('library') != 'OpenSSL':
+        raise Exception('Unsupported SSL library')

--- a/sdk/python/approzium/psycopg2.py
+++ b/sdk/python/approzium/psycopg2.py
@@ -15,7 +15,8 @@ from ._psycopg2_ctypes import (
     read_msg,
     write_msg,
     write_to_conn,
-    set_debug
+    set_debug,
+    ensure_compatible_ssl
 )
 from .authenticator import get_hash
 from .misc import read_int32_from_bytes
@@ -113,6 +114,7 @@ def construct_approzium_conn(base, is_sync):
             self._salt = None
             self._auth_type = None
             self._hash_sent = False
+            self._checked_ssl = False
             if is_sync:
                 wait(self)
                 set_connection_sync(self)
@@ -120,6 +122,10 @@ def construct_approzium_conn(base, is_sync):
 
         def poll(self):
             status = libpq_PQstatus(self.pgconn_ptr)
+            if self.info.ssl_in_use and not self._checked_ssl:
+                ensure_compatible_ssl(self)
+                logging.debug("checked ssl")
+                self._checked_ssl = True
             if status == self.CONNECTION_AWAITING_RESPONSE and not self._salt:
                 logging.debug("reading salt")
                 self._auth_type, self._salt = read_auth(self)


### PR DESCRIPTION
libpq seems to only support the OpenSSL API, based on the fact that it directly references it in its documentation. Based on [this discussion](https://www.postgresql.org/message-id/96dabede-e72a-b51f-13b9-c8d85216a7f0%40iki.fi) It seems that other libraries could try to implement that API.

We just load whatever `ssl` library the system is setup to find first. Therefore, it is possible we load a different library or version thereof than the one libpq is using. If libpq is using a different version, we expect that issues might happen. However, this is also the case with Psycopg2, which [might segfault](https://github.com/psycopg/psycopg2/issues/543). Therefore, we conclude that we do not add extra risk. 

As some sort of check, we ensure that libpq is indeed using OpenSSL and otherwise we raise an exception.