### PR TITLE
Update package name

### DIFF
--- a/authenticator/authenticator.go
+++ b/authenticator/authenticator.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	"approzium/authenticator/credmgrs"
-	pb "approzium/authenticator/protos"
+	"github.com/approzium/approzium/authenticator/credmgrs"
+	pb "github.com/approzium/approzium/authenticator/protos"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/pbkdf2"
 	"google.golang.org/grpc/codes"

--- a/authenticator/go.mod
+++ b/authenticator/go.mod
@@ -1,4 +1,4 @@
-module approzium/authenticator
+module github.com/approzium/approzium/authenticator
 
 go 1.13
 

--- a/authenticator/main.go
+++ b/authenticator/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pb "approzium/authenticator/protos"
+	pb "github.com/approzium/approzium/authenticator/protos"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"net"


### PR DESCRIPTION
This PR updates the authenticator's package name to fix `$ go get`, which was giving the following output previously:

```
$ go get github.com/approzium/approzium/authenticator
go: finding github.com/approzium/approzium latest
go: finding github.com/approzium/approzium/authenticator latest
go get: github.com/approzium/approzium/authenticator@v0.0.0-20200617171948-73c36c013a1b: parsing go.mod:
	module declares its path as: approzium/authenticator
	        but was required as: github.com/approzium/approzium/authenticator
```