### PR TITLE
Convert variables from snake case to camel case

### DIFF
--- a/authenticator/authenticator.go
+++ b/authenticator/authenticator.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	"approzium/authenticator/credmgrs"
-	pb "approzium/authenticator/protos"
+	"github.com/approzium/approzium/authenticator/credmgrs"
+	pb "github.com/approzium/approzium/authenticator/protos"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/pbkdf2"
 	"google.golang.org/grpc/codes"

--- a/authenticator/go.mod
+++ b/authenticator/go.mod
@@ -1,4 +1,4 @@
-module approzium/authenticator
+module github.com/approzium/approzium/authenticator
 
 go 1.13
 

--- a/authenticator/main.go
+++ b/authenticator/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	pb "approzium/authenticator/protos"
+	pb "github.com/approzium/approzium/authenticator/protos"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"net"


### PR DESCRIPTION
Just a super quick update from snake case to camel case because Go uses [mixed caps](https://golang.org/doc/effective_go.html#mixed-caps) for variable naming.