### PR TITLE
Python style fixes and a Go Unittest for xorBytes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           pip install isort black flake8
 
-      - run: isort --recursive --diff
-      - run: black .
-      - run: flake8
+      - run: cd sdk/python && isort --recursive --diff
+      - run: cd sdk/python && black .
+      - run: cd sdk/python && flake8
 
       # commit changes
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/authenticator/authenticator.go
+++ b/authenticator/authenticator.go
@@ -220,7 +220,7 @@ func computePGSHA256SaltedPass(password string, salt string, iterations int) ([]
 func xorBytes(a, b []byte) []byte {
 	buf := make([]byte, len(a))
 
-	for i, _ := range a {
+	for i := range a {
 		buf[i] = a[i] ^ b[i]
 	}
 

--- a/authenticator/authenticator_test.go
+++ b/authenticator/authenticator_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestXorBytes(t *testing.T) {
+	result := xorBytes([]byte{0}, []byte{0})
+	expected := []byte{0}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %#v, but received %#v", expected, result)
+	}
+
+	result = xorBytes([]byte{1}, []byte{1})
+	expected = []byte{0}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %#v, but received %#v", expected, result)
+	}
+
+	result = xorBytes([]byte{0, 1, 1}, []byte{0, 1, 1})
+	expected = []byte{0, 0, 0}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %#v, but received %#v", expected, result)
+	}
+
+	result = xorBytes([]byte{1, 1, 1}, []byte{0, 0, 0})
+	expected = []byte{1, 1, 1}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %#v, but received %#v", expected, result)
+	}
+}

--- a/sdk/python/.flake8
+++ b/sdk/python/.flake8
@@ -7,5 +7,6 @@ exclude =
     dist,
     tests/pg2_testsuite/
     approzium/protos/
+    setup.py
 extend-ignore =
     E203

--- a/sdk/python/.flake8
+++ b/sdk/python/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+max-line-length = 88
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    tests/pg2_testsuite/
+    approzium/protos/
+extend-ignore =
+    E203

--- a/sdk/python/approzium/__init__.py
+++ b/sdk/python/approzium/__init__.py
@@ -1,17 +1,15 @@
 import logging
-from .authenticator import Authenticator
 
-authenticator_addr = "authenticator:1234"
-iam_role = None
 
+default_authenticator = None
 logger = logging.getLogger(__name__)
+log_format = "[%(filename)s:%(lineno)s - %(funcName)10s() ] %(message)s"
+formatter = logging.Formatter(log_format)
 ch = logging.StreamHandler()
-formatter = logging.Formatter("[%(filename)s:%(lineno)s - %(funcName)10s() ] %(message)s")
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
 
-default_authenticator = None
 def set_default_authenticator(new_authenticator):
     global default_authenticator
     default_authenticator = new_authenticator

--- a/sdk/python/approzium/__init__.py
+++ b/sdk/python/approzium/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from .authenticator import Authenticator
 
 
 default_authenticator = None
@@ -13,3 +14,6 @@ logger.addHandler(ch)
 def set_default_authenticator(new_authenticator):
     global default_authenticator
     default_authenticator = new_authenticator
+
+
+__all__ = ['set_default_authenticator', 'Authenticator']

--- a/sdk/python/approzium/_psycopg2_ctypes.py
+++ b/sdk/python/approzium/_psycopg2_ctypes.py
@@ -63,13 +63,13 @@ def set_connection_sync(pgconn):
 
     def ensure(check):
         if not check:
-            raise Exception('Could not set connection to sync. Unidentified struct field')
+            raise Exception('Could not set connection to sync. Unidentified struct')
 
     # as a check, we check server and protocol version numbers, which succeed
     # the async value in the psycopg connection struct
     server_version_addr = addressofint(pgconn.server_version)
     # check that there is only one match for that value
-    ensure (
+    ensure(
         addressofint(pgconn.server_version, mem[server_version_addr + sizeofint :])
         == -1
     )
@@ -130,10 +130,12 @@ def write_to_conn(pgconn, msg):
             sock.sendall(msg)
     logger.debug(f'sent: {msg}')
 
+
 def set_debug(conn):
     libc = CDLL(find_library('c'))
     stdout = c_void_p.in_dll(libc, 'stdout')
     libpq.PQtrace(conn.pgconn_ptr, stdout)
+
 
 def ensure_compatible_ssl(conn):
     if conn.info.ssl_attribute('library') != 'OpenSSL':

--- a/sdk/python/approzium/_psycopg2_ctypes.py
+++ b/sdk/python/approzium/_psycopg2_ctypes.py
@@ -63,7 +63,7 @@ def set_connection_sync(pgconn):
 
     def ensure(check):
         if not check:
-            raise Exception('Could not set connection to sync. Unidentified struct')
+            raise Exception("Could not set connection to sync. Unidentified struct")
 
     # as a check, we check server and protocol version numbers, which succeed
     # the async value in the psycopg connection struct
@@ -106,13 +106,13 @@ def read_msg(pgconn):
 
     msg_type = read_bytes(1)
     msg_size = struct.unpack("!i", read_bytes(4))[0]
-    msg_content = read_bytes(msg_size-4)
-    logger.debug(f'read: {msg_type} {msg_content}')
+    msg_content = read_bytes(msg_size - 4)
+    logger.debug(f"read: {msg_type} {msg_content}")
     return msg_type, msg_content
 
 
 def write_msg(pgconn, msg_header, msg):
-    msg = msg_header + struct.pack("!i", len(msg)+4) + msg
+    msg = msg_header + struct.pack("!i", len(msg) + 4) + msg
     write_to_conn(pgconn, msg)
 
 
@@ -128,15 +128,15 @@ def write_to_conn(pgconn, msg):
             warnings.simplefilter("ignore", ResourceWarning)
             sock = fromfd(pgconn.fileno(), keep_fd=True)
             sock.sendall(msg)
-    logger.debug(f'sent: {msg}')
+    logger.debug(f"sent: {msg}")
 
 
 def set_debug(conn):
-    libc = CDLL(find_library('c'))
-    stdout = c_void_p.in_dll(libc, 'stdout')
+    libc = CDLL(find_library("c"))
+    stdout = c_void_p.in_dll(libc, "stdout")
     libpq.PQtrace(conn.pgconn_ptr, stdout)
 
 
 def ensure_compatible_ssl(conn):
-    if conn.info.ssl_attribute('library') != 'OpenSSL':
-        raise Exception('Unsupported SSL library')
+    if conn.info.ssl_attribute("library") != "OpenSSL":
+        raise Exception("Unsupported SSL library")

--- a/sdk/python/approzium/_psycopg2_scram.py
+++ b/sdk/python/approzium/_psycopg2_scram.py
@@ -95,7 +95,7 @@ class SCRAMAuthentication:
             raise Exception("could not get salt")
         try:
             self.password_iterations = int(
-                re.search(b"i=(\d+),?", self.server_first_message).group(1)
+                re.search(b"i=(\d+),?", self.server_first_message).group(1)  # noqa:W605
             )
         except (IndexError, TypeError, ValueError):
             raise Exception("could not get iterations")

--- a/sdk/python/approzium/authenticator.py
+++ b/sdk/python/approzium/authenticator.py
@@ -2,6 +2,7 @@ import approzium
 import grpc
 from pathlib import Path
 from .iam import obtain_signed_get_caller_identity
+
 # needed to be able to import protos code
 import sys
 
@@ -46,7 +47,7 @@ def get_hash(dbhost, dbport, dbuser, auth_type, auth_info, authenticator):
             dbuser=dbuser,
             salt=auth.password_salt,
             iterations=auth.password_iterations,
-            authentication_msg=auth.authorization_message
+            authentication_msg=auth.authorization_message,
         )
         response = stub.GetPGSHA256Hash(request)
         client_final = auth.create_client_final_message(response.cproof)

--- a/sdk/python/approzium/authenticator.py
+++ b/sdk/python/approzium/authenticator.py
@@ -1,22 +1,20 @@
 import approzium
-import logging
-import hashlib
 import grpc
 from pathlib import Path
-
+from .iam import obtain_signed_get_caller_identity
 # needed to be able to import protos code
 import sys
 
 sys.path.append(str(Path(__file__).parent / "protos"))
-import authenticator_pb2_grpc
-import authenticator_pb2
-from .iam import obtain_signed_get_caller_identity
+import authenticator_pb2_grpc  # noqa: E402
+import authenticator_pb2  # noqa: E402
 
 
 class Authenticator(object):
     def __init__(self, address, iam_role=None):
         self.address = address
         self.iam_role = iam_role
+
 
 def get_hash(dbhost, dbport, dbuser, auth_type, auth_info, authenticator):
     signed_gci = obtain_signed_get_caller_identity(authenticator.iam_role)

--- a/sdk/python/approzium/iam.py
+++ b/sdk/python/approzium/iam.py
@@ -1,10 +1,9 @@
 import boto3
-import approzium
 
 
 def obtain_signed_get_caller_identity(iam_role):
     if iam_role is None:
-        raise NotImplementedError('Automatic IAM ARN determination is not implemented yet')
+        raise NotImplementedError('Automatic IAM ARN determination is not implemented')
     sts_client = boto3.client("sts")
     credentials = sts_client.assume_role(
         DurationSeconds=3600, RoleArn=iam_role, RoleSessionName="Service1",

--- a/sdk/python/approzium/iam.py
+++ b/sdk/python/approzium/iam.py
@@ -3,7 +3,7 @@ import boto3
 
 def obtain_signed_get_caller_identity(iam_role):
     if iam_role is None:
-        raise NotImplementedError('Automatic IAM ARN determination is not implemented')
+        raise NotImplementedError("Automatic IAM ARN determination is not implemented")
     sts_client = boto3.client("sts")
     credentials = sts_client.assume_role(
         DurationSeconds=3600, RoleArn=iam_role, RoleSessionName="Service1",

--- a/sdk/python/approzium/misc.py
+++ b/sdk/python/approzium/misc.py
@@ -4,6 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def read_int32_from_bytes(bytes, index):
     num = struct.unpack("!i", bytes[index : index + 4])[0]
     return num

--- a/sdk/python/approzium/protos/authenticator_pb2.py
+++ b/sdk/python/approzium/protos/authenticator_pb2.py
@@ -6,304 +6,492 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='authenticator.proto',
-  package='approzium.authenticator.protos',
-  syntax='proto3',
-  serialized_options=None,
-  serialized_pb=b'\n\x13\x61uthenticator.proto\x12\x1e\x61pprozium.authenticator.protos\"\x8d\x01\n\x10PGMD5HashRequest\x12\"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62port\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x05 \x01(\t\x12\x0c\n\x04salt\x18\x06 \x01(\x0c\"\xc0\x01\n\x13PGSHA256HashRequest\x12\"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62port\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x05 \x01(\t\x12\x0c\n\x04salt\x18\x06 \x01(\t\x12\x12\n\niterations\x18\x07 \x01(\r\x12\x1a\n\x12\x61uthentication_msg\x18\x08 \x01(\t\"\x1d\n\rPGMD5Response\x12\x0c\n\x04hash\x18\x01 \x01(\t\"2\n\x10PGSHA256Response\x12\x0e\n\x06\x63proof\x18\x01 \x01(\t\x12\x0e\n\x06sproof\x18\x02 \x01(\t2\xfe\x01\n\rAuthenticator\x12q\n\x0cGetPGMD5Hash\x12\x30.approzium.authenticator.protos.PGMD5HashRequest\x1a-.approzium.authenticator.protos.PGMD5Response\"\x00\x12z\n\x0fGetPGSHA256Hash\x12\x33.approzium.authenticator.protos.PGSHA256HashRequest\x1a\x30.approzium.authenticator.protos.PGSHA256Response\"\x00\x62\x06proto3'
+    name="authenticator.proto",
+    package="approzium.authenticator.protos",
+    syntax="proto3",
+    serialized_options=None,
+    serialized_pb=b'\n\x13\x61uthenticator.proto\x12\x1e\x61pprozium.authenticator.protos"\x8d\x01\n\x10PGMD5HashRequest\x12"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62port\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x05 \x01(\t\x12\x0c\n\x04salt\x18\x06 \x01(\x0c"\xc0\x01\n\x13PGSHA256HashRequest\x12"\n\x1asigned_get_caller_identity\x18\x01 \x01(\t\x12\x17\n\x0f\x63laimed_iam_arn\x18\x02 \x01(\t\x12\x0e\n\x06\x64\x62host\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x62port\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x62user\x18\x05 \x01(\t\x12\x0c\n\x04salt\x18\x06 \x01(\t\x12\x12\n\niterations\x18\x07 \x01(\r\x12\x1a\n\x12\x61uthentication_msg\x18\x08 \x01(\t"\x1d\n\rPGMD5Response\x12\x0c\n\x04hash\x18\x01 \x01(\t"2\n\x10PGSHA256Response\x12\x0e\n\x06\x63proof\x18\x01 \x01(\t\x12\x0e\n\x06sproof\x18\x02 \x01(\t2\xfe\x01\n\rAuthenticator\x12q\n\x0cGetPGMD5Hash\x12\x30.approzium.authenticator.protos.PGMD5HashRequest\x1a-.approzium.authenticator.protos.PGMD5Response"\x00\x12z\n\x0fGetPGSHA256Hash\x12\x33.approzium.authenticator.protos.PGSHA256HashRequest\x1a\x30.approzium.authenticator.protos.PGSHA256Response"\x00\x62\x06proto3',
 )
 
 
-
-
 _PGMD5HASHREQUEST = _descriptor.Descriptor(
-  name='PGMD5HashRequest',
-  full_name='approzium.authenticator.protos.PGMD5HashRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='signed_get_caller_identity', full_name='approzium.authenticator.protos.PGMD5HashRequest.signed_get_caller_identity', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='claimed_iam_arn', full_name='approzium.authenticator.protos.PGMD5HashRequest.claimed_iam_arn', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='dbhost', full_name='approzium.authenticator.protos.PGMD5HashRequest.dbhost', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='dbport', full_name='approzium.authenticator.protos.PGMD5HashRequest.dbport', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='dbuser', full_name='approzium.authenticator.protos.PGMD5HashRequest.dbuser', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='salt', full_name='approzium.authenticator.protos.PGMD5HashRequest.salt', index=5,
-      number=6, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=56,
-  serialized_end=197,
+    name="PGMD5HashRequest",
+    full_name="approzium.authenticator.protos.PGMD5HashRequest",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="signed_get_caller_identity",
+            full_name="approzium.authenticator.protos.PGMD5HashRequest.signed_get_caller_identity",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="claimed_iam_arn",
+            full_name="approzium.authenticator.protos.PGMD5HashRequest.claimed_iam_arn",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="dbhost",
+            full_name="approzium.authenticator.protos.PGMD5HashRequest.dbhost",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="dbport",
+            full_name="approzium.authenticator.protos.PGMD5HashRequest.dbport",
+            index=3,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="dbuser",
+            full_name="approzium.authenticator.protos.PGMD5HashRequest.dbuser",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="salt",
+            full_name="approzium.authenticator.protos.PGMD5HashRequest.salt",
+            index=5,
+            number=6,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"",
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=56,
+    serialized_end=197,
 )
 
 
 _PGSHA256HASHREQUEST = _descriptor.Descriptor(
-  name='PGSHA256HashRequest',
-  full_name='approzium.authenticator.protos.PGSHA256HashRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='signed_get_caller_identity', full_name='approzium.authenticator.protos.PGSHA256HashRequest.signed_get_caller_identity', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='claimed_iam_arn', full_name='approzium.authenticator.protos.PGSHA256HashRequest.claimed_iam_arn', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='dbhost', full_name='approzium.authenticator.protos.PGSHA256HashRequest.dbhost', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='dbport', full_name='approzium.authenticator.protos.PGSHA256HashRequest.dbport', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='dbuser', full_name='approzium.authenticator.protos.PGSHA256HashRequest.dbuser', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='salt', full_name='approzium.authenticator.protos.PGSHA256HashRequest.salt', index=5,
-      number=6, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='iterations', full_name='approzium.authenticator.protos.PGSHA256HashRequest.iterations', index=6,
-      number=7, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='authentication_msg', full_name='approzium.authenticator.protos.PGSHA256HashRequest.authentication_msg', index=7,
-      number=8, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=200,
-  serialized_end=392,
+    name="PGSHA256HashRequest",
+    full_name="approzium.authenticator.protos.PGSHA256HashRequest",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="signed_get_caller_identity",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.signed_get_caller_identity",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="claimed_iam_arn",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.claimed_iam_arn",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="dbhost",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.dbhost",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="dbport",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.dbport",
+            index=3,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="dbuser",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.dbuser",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="salt",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.salt",
+            index=5,
+            number=6,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="iterations",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.iterations",
+            index=6,
+            number=7,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="authentication_msg",
+            full_name="approzium.authenticator.protos.PGSHA256HashRequest.authentication_msg",
+            index=7,
+            number=8,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=200,
+    serialized_end=392,
 )
 
 
 _PGMD5RESPONSE = _descriptor.Descriptor(
-  name='PGMD5Response',
-  full_name='approzium.authenticator.protos.PGMD5Response',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='hash', full_name='approzium.authenticator.protos.PGMD5Response.hash', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=394,
-  serialized_end=423,
+    name="PGMD5Response",
+    full_name="approzium.authenticator.protos.PGMD5Response",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="hash",
+            full_name="approzium.authenticator.protos.PGMD5Response.hash",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=394,
+    serialized_end=423,
 )
 
 
 _PGSHA256RESPONSE = _descriptor.Descriptor(
-  name='PGSHA256Response',
-  full_name='approzium.authenticator.protos.PGSHA256Response',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='cproof', full_name='approzium.authenticator.protos.PGSHA256Response.cproof', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='sproof', full_name='approzium.authenticator.protos.PGSHA256Response.sproof', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=425,
-  serialized_end=475,
+    name="PGSHA256Response",
+    full_name="approzium.authenticator.protos.PGSHA256Response",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="cproof",
+            full_name="approzium.authenticator.protos.PGSHA256Response.cproof",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="sproof",
+            full_name="approzium.authenticator.protos.PGSHA256Response.sproof",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=425,
+    serialized_end=475,
 )
 
-DESCRIPTOR.message_types_by_name['PGMD5HashRequest'] = _PGMD5HASHREQUEST
-DESCRIPTOR.message_types_by_name['PGSHA256HashRequest'] = _PGSHA256HASHREQUEST
-DESCRIPTOR.message_types_by_name['PGMD5Response'] = _PGMD5RESPONSE
-DESCRIPTOR.message_types_by_name['PGSHA256Response'] = _PGSHA256RESPONSE
+DESCRIPTOR.message_types_by_name["PGMD5HashRequest"] = _PGMD5HASHREQUEST
+DESCRIPTOR.message_types_by_name["PGSHA256HashRequest"] = _PGSHA256HASHREQUEST
+DESCRIPTOR.message_types_by_name["PGMD5Response"] = _PGMD5RESPONSE
+DESCRIPTOR.message_types_by_name["PGSHA256Response"] = _PGSHA256RESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-PGMD5HashRequest = _reflection.GeneratedProtocolMessageType('PGMD5HashRequest', (_message.Message,), {
-  'DESCRIPTOR' : _PGMD5HASHREQUEST,
-  '__module__' : 'authenticator_pb2'
-  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGMD5HashRequest)
-  })
+PGMD5HashRequest = _reflection.GeneratedProtocolMessageType(
+    "PGMD5HashRequest",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _PGMD5HASHREQUEST,
+        "__module__": "authenticator_pb2"
+        # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGMD5HashRequest)
+    },
+)
 _sym_db.RegisterMessage(PGMD5HashRequest)
 
-PGSHA256HashRequest = _reflection.GeneratedProtocolMessageType('PGSHA256HashRequest', (_message.Message,), {
-  'DESCRIPTOR' : _PGSHA256HASHREQUEST,
-  '__module__' : 'authenticator_pb2'
-  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGSHA256HashRequest)
-  })
+PGSHA256HashRequest = _reflection.GeneratedProtocolMessageType(
+    "PGSHA256HashRequest",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _PGSHA256HASHREQUEST,
+        "__module__": "authenticator_pb2"
+        # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGSHA256HashRequest)
+    },
+)
 _sym_db.RegisterMessage(PGSHA256HashRequest)
 
-PGMD5Response = _reflection.GeneratedProtocolMessageType('PGMD5Response', (_message.Message,), {
-  'DESCRIPTOR' : _PGMD5RESPONSE,
-  '__module__' : 'authenticator_pb2'
-  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGMD5Response)
-  })
+PGMD5Response = _reflection.GeneratedProtocolMessageType(
+    "PGMD5Response",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _PGMD5RESPONSE,
+        "__module__": "authenticator_pb2"
+        # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGMD5Response)
+    },
+)
 _sym_db.RegisterMessage(PGMD5Response)
 
-PGSHA256Response = _reflection.GeneratedProtocolMessageType('PGSHA256Response', (_message.Message,), {
-  'DESCRIPTOR' : _PGSHA256RESPONSE,
-  '__module__' : 'authenticator_pb2'
-  # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGSHA256Response)
-  })
+PGSHA256Response = _reflection.GeneratedProtocolMessageType(
+    "PGSHA256Response",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _PGSHA256RESPONSE,
+        "__module__": "authenticator_pb2"
+        # @@protoc_insertion_point(class_scope:approzium.authenticator.protos.PGSHA256Response)
+    },
+)
 _sym_db.RegisterMessage(PGSHA256Response)
 
 
-
 _AUTHENTICATOR = _descriptor.ServiceDescriptor(
-  name='Authenticator',
-  full_name='approzium.authenticator.protos.Authenticator',
-  file=DESCRIPTOR,
-  index=0,
-  serialized_options=None,
-  serialized_start=478,
-  serialized_end=732,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='GetPGMD5Hash',
-    full_name='approzium.authenticator.protos.Authenticator.GetPGMD5Hash',
+    name="Authenticator",
+    full_name="approzium.authenticator.protos.Authenticator",
+    file=DESCRIPTOR,
     index=0,
-    containing_service=None,
-    input_type=_PGMD5HASHREQUEST,
-    output_type=_PGMD5RESPONSE,
     serialized_options=None,
-  ),
-  _descriptor.MethodDescriptor(
-    name='GetPGSHA256Hash',
-    full_name='approzium.authenticator.protos.Authenticator.GetPGSHA256Hash',
-    index=1,
-    containing_service=None,
-    input_type=_PGSHA256HASHREQUEST,
-    output_type=_PGSHA256RESPONSE,
-    serialized_options=None,
-  ),
-])
+    serialized_start=478,
+    serialized_end=732,
+    methods=[
+        _descriptor.MethodDescriptor(
+            name="GetPGMD5Hash",
+            full_name="approzium.authenticator.protos.Authenticator.GetPGMD5Hash",
+            index=0,
+            containing_service=None,
+            input_type=_PGMD5HASHREQUEST,
+            output_type=_PGMD5RESPONSE,
+            serialized_options=None,
+        ),
+        _descriptor.MethodDescriptor(
+            name="GetPGSHA256Hash",
+            full_name="approzium.authenticator.protos.Authenticator.GetPGSHA256Hash",
+            index=1,
+            containing_service=None,
+            input_type=_PGSHA256HASHREQUEST,
+            output_type=_PGSHA256RESPONSE,
+            serialized_options=None,
+        ),
+    ],
+)
 _sym_db.RegisterServiceDescriptor(_AUTHENTICATOR)
 
-DESCRIPTOR.services_by_name['Authenticator'] = _AUTHENTICATOR
+DESCRIPTOR.services_by_name["Authenticator"] = _AUTHENTICATOR
 
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/approzium/protos/authenticator_pb2_grpc.py
+++ b/sdk/python/approzium/protos/authenticator_pb2_grpc.py
@@ -14,15 +14,15 @@ class AuthenticatorStub(object):
             channel: A grpc.Channel.
         """
         self.GetPGMD5Hash = channel.unary_unary(
-                '/approzium.authenticator.protos.Authenticator/GetPGMD5Hash',
-                request_serializer=authenticator__pb2.PGMD5HashRequest.SerializeToString,
-                response_deserializer=authenticator__pb2.PGMD5Response.FromString,
-                )
+            "/approzium.authenticator.protos.Authenticator/GetPGMD5Hash",
+            request_serializer=authenticator__pb2.PGMD5HashRequest.SerializeToString,
+            response_deserializer=authenticator__pb2.PGMD5Response.FromString,
+        )
         self.GetPGSHA256Hash = channel.unary_unary(
-                '/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash',
-                request_serializer=authenticator__pb2.PGSHA256HashRequest.SerializeToString,
-                response_deserializer=authenticator__pb2.PGSHA256Response.FromString,
-                )
+            "/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash",
+            request_serializer=authenticator__pb2.PGSHA256HashRequest.SerializeToString,
+            response_deserializer=authenticator__pb2.PGSHA256Response.FromString,
+        )
 
 
 class AuthenticatorServicer(object):
@@ -31,66 +31,89 @@ class AuthenticatorServicer(object):
     def GetPGMD5Hash(self, request, context):
         """Missing associated documentation comment in .proto file"""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
 
     def GetPGSHA256Hash(self, request, context):
         """Missing associated documentation comment in .proto file"""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
 
 
 def add_AuthenticatorServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'GetPGMD5Hash': grpc.unary_unary_rpc_method_handler(
-                    servicer.GetPGMD5Hash,
-                    request_deserializer=authenticator__pb2.PGMD5HashRequest.FromString,
-                    response_serializer=authenticator__pb2.PGMD5Response.SerializeToString,
-            ),
-            'GetPGSHA256Hash': grpc.unary_unary_rpc_method_handler(
-                    servicer.GetPGSHA256Hash,
-                    request_deserializer=authenticator__pb2.PGSHA256HashRequest.FromString,
-                    response_serializer=authenticator__pb2.PGSHA256Response.SerializeToString,
-            ),
+        "GetPGMD5Hash": grpc.unary_unary_rpc_method_handler(
+            servicer.GetPGMD5Hash,
+            request_deserializer=authenticator__pb2.PGMD5HashRequest.FromString,
+            response_serializer=authenticator__pb2.PGMD5Response.SerializeToString,
+        ),
+        "GetPGSHA256Hash": grpc.unary_unary_rpc_method_handler(
+            servicer.GetPGSHA256Hash,
+            request_deserializer=authenticator__pb2.PGSHA256HashRequest.FromString,
+            response_serializer=authenticator__pb2.PGSHA256Response.SerializeToString,
+        ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'approzium.authenticator.protos.Authenticator', rpc_method_handlers)
+        "approzium.authenticator.protos.Authenticator", rpc_method_handlers
+    )
     server.add_generic_rpc_handlers((generic_handler,))
 
 
- # This class is part of an EXPERIMENTAL API.
+# This class is part of an EXPERIMENTAL API.
 class Authenticator(object):
     """Missing associated documentation comment in .proto file"""
 
     @staticmethod
-    def GetPGMD5Hash(request,
+    def GetPGMD5Hash(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
             target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/approzium.authenticator.protos.Authenticator/GetPGMD5Hash',
+            "/approzium.authenticator.protos.Authenticator/GetPGMD5Hash",
             authenticator__pb2.PGMD5HashRequest.SerializeToString,
             authenticator__pb2.PGMD5Response.FromString,
-            options, channel_credentials,
-            call_credentials, compression, wait_for_ready, timeout, metadata)
+            options,
+            channel_credentials,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
 
     @staticmethod
-    def GetPGSHA256Hash(request,
+    def GetPGSHA256Hash(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
             target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash',
+            "/approzium.authenticator.protos.Authenticator/GetPGSHA256Hash",
             authenticator__pb2.PGSHA256HashRequest.SerializeToString,
             authenticator__pb2.PGSHA256Response.FromString,
-            options, channel_credentials,
-            call_credentials, compression, wait_for_ready, timeout, metadata)
+            options,
+            channel_credentials,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )

--- a/sdk/python/client.py
+++ b/sdk/python/client.py
@@ -1,4 +1,4 @@
-import psycopg2
+from os import environ
 from approzium import Authenticator, set_default_authenticator
 from approzium.psycopg2 import connect
 import logging
@@ -7,12 +7,15 @@ logger = logging.getLogger('approzium')
 logger.setLevel(logging.DEBUG)
 
 
-auth = Authenticator('authenticator:1234', 'arn:aws:iam::accountid:role/rolename')
+auth = Authenticator('authenticator:1234',
+                     iam_role=environ.get('TEST_IAM_ROLE'))
 set_default_authenticator(auth)
 conn = connect("")  # or connect("", authenticator=auth)
 print('Connection Established')
 
+
 def test():
     conn.cursor().execute('SELECT 1')
+
 
 test()

--- a/sdk/python/client.py
+++ b/sdk/python/client.py
@@ -3,19 +3,18 @@ from approzium import Authenticator, set_default_authenticator
 from approzium.psycopg2 import connect
 import logging
 
-logger = logging.getLogger('approzium')
+logger = logging.getLogger("approzium")
 logger.setLevel(logging.DEBUG)
 
 
-auth = Authenticator('authenticator:1234',
-                     iam_role=environ.get('TEST_IAM_ROLE'))
+auth = Authenticator("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
 set_default_authenticator(auth)
 conn = connect("")  # or connect("", authenticator=auth)
-print('Connection Established')
+print("Connection Established")
 
 
 def test():
-    conn.cursor().execute('SELECT 1')
+    conn.cursor().execute("SELECT 1")
 
 
 test()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+target-version = ['py37']
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.hg          # root of the project
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | approzium/protos
+)
+'''

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -1,22 +1,18 @@
 import setuptools
 
-long_description = open('README.md', 'r').read()
+long_description = open("README.md", "r").read()
 
 
 setuptools.setup(
-        name='approzium',
-        description='Python SDK for Approzium',
-        long_description=long_description,
-        long_description_content_type='text/markdown',
-        url='https://github.com/approzium/approzium/',
-        packages=setuptools.find_packages(),
-        classifiers=[
-            "Programming Language :: Python :: 3",
-            "Operating System :: OS Independent",
-        ],
-        install_requires=[
-            'psycopg2',
-            'boto3',
-            'grpcio',
-        ]
+    name="approzium",
+    description="Python SDK for Approzium",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/approzium/approzium/",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=["psycopg2", "boto3", "grpcio",],
 )

--- a/sdk/python/tests/run_pg2_testsuite.py
+++ b/sdk/python/tests/run_pg2_testsuite.py
@@ -7,16 +7,14 @@ from unittest import SkipTest
 import os
 from os.path import abspath
 import logging
-import sys
-
-sys.path.append(abspath("pg2_testsuite"))
-import hashlib
 from approzium import Authenticator, set_default_authenticator
 
 # once get hash is mocked, import connect method
 from approzium.psycopg2 import connect as approzium_pg2_connect
-import pg2_testsuite
 import psycopg2
+import sys
+sys.path.append(abspath("pg2_testsuite"))
+import pg2_testsuite  # noqa: E402 F401
 
 
 try:
@@ -34,7 +32,8 @@ psycopg2.connect = approzium_pg2_connect
 
 def skip_tests(ids, pg2_suites):
     filtered_suite = unittest.TestSuite()
-    # the way the Psycopg2 test suite is setup, there are many layers of organization
+    # the way the Psycopg2 test suite is setup, there are many layers of
+    # organization
     for suites in pg2_suites:
         for suite in suites:
             for test in suite:

--- a/sdk/python/tests/run_pg2_testsuite.py
+++ b/sdk/python/tests/run_pg2_testsuite.py
@@ -13,17 +13,18 @@ from approzium import Authenticator, set_default_authenticator
 from approzium.psycopg2 import connect as approzium_pg2_connect
 import psycopg2
 import sys
+
 sys.path.append(abspath("pg2_testsuite"))
 import pg2_testsuite  # noqa: E402 F401
 
 
 try:
-    test_iam_role = os.environ['TEST_IAM_ROLE']
+    test_iam_role = os.environ["TEST_IAM_ROLE"]
 except KeyError:
     print("Please set env var 'TEST_IAM_ROLE' to a valid value")
     sys.exit(1)
 
-auth = Authenticator('authenticator:1234', test_iam_role)
+auth = Authenticator("authenticator:1234", test_iam_role)
 set_default_authenticator(auth)
 
 # replace connect method

--- a/sdk/python/tests/test_approzium_sdk.py
+++ b/sdk/python/tests/test_approzium_sdk.py
@@ -1,5 +1,3 @@
-import approzium
-import approzium.misc
 from approzium.misc import read_int32_from_bytes
 
 


### PR DESCRIPTION
- Fixes many style errors such that CI lint stage passes (except for a Syntax error that is handled in #42 
- Add `pyproject.toml` and `.flake8` files for configuring style checkers