### PR TITLE
Run Python tests in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install -y \
   python3.7-dev \
   python3-pip
 RUN pip3 install --upgrade pip
-RUN pip3 install pytest
+RUN pip3 install pytest pytest-parallel
 # Install protobuf compiler for Python
 RUN pip3 install grpcio-tools
 # Python package dependencies. Repeated here for faster cached build time

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ run-gotests:
 	cd authenticator && CGO_ENABLED=1 go test -v -race ./...
 
 run-pythontests: enable-vault-path seed-vault-all-hosts
-	cd sdk/python && pytest
+	cd sdk/python && pytest --workers auto
 
 run-pg2tests: enable-vault-path seed-vault-all-hosts
 	for HOST in $(TEST_DBHOSTS); do \


### PR DESCRIPTION
Using `pytest-parallel` plugin, we get a little speed up in running tests. For example, 9.2 sec vs 18.6 sec running on Github Actions. Will be helpful too when we add more tests in the future.