### PR TITLE
Add automatic ARN determination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # approzium
-credential-less database authentication for services
+Approzium provides SDKs that allow you to authenticate to a database without ever having access to its password. Your
+identity is provided through the platform on which you're running.
+
+We currently support AWS for identity, and have a Python SDK for Postres. This project is under active development, please
+do stay tuned for more identity platforms, databases, and SDK languages.
+
+## Docs
+
+See https://approzium.org/ for a Quick Start, or elaboration on the architecture and API.
 
 ## Developing
 
@@ -18,3 +26,7 @@ To drop into a Bash shell into the development environment, run `make dev`. This
 - Export an environment variable for the role you're testing with: `$ export TEST_IAM_ROLE=arn:aws:iam::123456789012:role/AssumableRole`.
 - To use our Python SDK to shoot a request at the authenticator, run
   `$ PGHOST=dbmd5 PGUSER=bob PGDATABASE=db python3 sdk/python/client.py`.
+  
+## Credits
+
+This project is brought to you by [Cyral](https://www.cyral.com/), who wishes to give back to the Open Source community.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To drop into a Bash shell into the development environment, run `make dev`. This
 - In another window, `$ make dev`
 - Export an environment variable for the role you're testing with: `$ export TEST_IAM_ROLE=arn:aws:iam::123456789012:role/AssumableRole`.
 - To use our Python SDK to shoot a request at the authenticator, run
-  `$ PGHOST=dbmd5 PGUSER=bob PGDATABASE=db python3 sdk/python/client.py`.
+  `$ PGHOST=dbmd5 PGUSER=bob PGDATABASE=db python3 sdk/python/examples/pg2_client.py`.
   
 ## Credits
 

--- a/sdk/python/approzium/authenticator.py
+++ b/sdk/python/approzium/authenticator.py
@@ -48,8 +48,7 @@ def get_hash(dbhost, dbport, dbuser, auth_type, auth_info, authenticator):
             dbuser=dbuser,
             dbport=dbport,
             awsauth=authenticator_pb2.AWSAuth(
-                signed_get_caller_identity=signed_gci,
-                claimed_iam_arn=claimed_arn,
+                signed_get_caller_identity=signed_gci, claimed_iam_arn=claimed_arn,
             ),
             salt=salt,
         )
@@ -65,8 +64,7 @@ def get_hash(dbhost, dbport, dbuser, auth_type, auth_info, authenticator):
             dbport=dbport,
             dbuser=dbuser,
             awsauth=authenticator_pb2.AWSAuth(
-                signed_get_caller_identity=signed_gci,
-                claimed_iam_arn=claimed_arn,
+                signed_get_caller_identity=signed_gci, claimed_iam_arn=claimed_arn,
             ),
             salt=auth.password_salt,
             iterations=auth.password_iterations,

--- a/sdk/python/approzium/authenticator.py
+++ b/sdk/python/approzium/authenticator.py
@@ -1,7 +1,6 @@
 # needed to be able to import protos code
 import sys
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from itertools import count
 from pathlib import Path
 
@@ -65,7 +64,8 @@ class AuthClient(object):
         request.client_language = authenticator_pb2.PYTHON
         request.awsauth.CopyFrom(
             authenticator_pb2.AWSAuth(
-                signed_get_caller_identity=self.signed_gci, claimed_iam_arn=self.claimed_arn,
+                signed_get_caller_identity=self.signed_gci,
+                claimed_iam_arn=self.claimed_arn,
             )
         )
         response = getattr(stub, getmethodname)(request)
@@ -103,7 +103,7 @@ class AuthClient(object):
     # The presigned GetCallerIdentity string expires every 15 minuts, so refresh it
     # after 5 minutes just to be safe.
     def _update_gci_if_needed(self):
-        if datetime.utcnow() - self.signed_gci_last_updated < timedelta(minutes = 5):
+        if datetime.utcnow() - self.signed_gci_last_updated < timedelta(minutes=5):
             return
         if self.iam_role is None:
             self.signed_gci = obtain_signed_get_caller_identity(None)

--- a/sdk/python/approzium/authenticator.py
+++ b/sdk/python/approzium/authenticator.py
@@ -1,5 +1,7 @@
 # needed to be able to import protos code
 import sys
+from datetime import datetime
+from datetime import timedelta
 from itertools import count
 from pathlib import Path
 
@@ -22,10 +24,26 @@ import authenticator_pb2_grpc  # noqa: E402 isort:skip
 class AuthClient(object):
     def __init__(self, server_address, iam_role=None):
         self.server_address = server_address
-        self.iam_role = iam_role
         self.authenticated = False
         self._counter = count(1)
         self.n_conns = 0
+        self.iam_role = iam_role
+
+        # Parse the claimed ARN once because it'll never change.
+        # Parse the signed_gci at startup, and then we'll update
+        # it every 5 minutes because it expires every 15.
+        if iam_role is None:
+            claimed_arn = get_local_arn()
+            signed_gci = obtain_signed_get_caller_identity(None)
+        else:
+            response = assume_role(iam_role)
+            credentials = obtain_credentials(response)
+            claimed_arn = obtain_claimed_arn(response)
+            signed_gci = obtain_signed_get_caller_identity(credentials)
+
+        self.claimed_arn = claimed_arn
+        self.signed_gci = signed_gci
+        self.signed_gci_last_updated = datetime.utcnow()
 
     @property
     def attribution_info(self):
@@ -36,16 +54,9 @@ class AuthClient(object):
         info["num_connections"] = self.n_conns
         return info
 
-
     def _execute_request(self, request, getmethodname):
-        if self.iam_role is None:
-            claimed_arn = get_local_arn()
-            signed_gci = obtain_signed_get_caller_identity(None)
-        else:
-            response = assume_role(self.iam_role)
-            credentials = obtain_credentials(response)
-            claimed_arn = obtain_claimed_arn(response)
-            signed_gci = obtain_signed_get_caller_identity(credentials)
+        # The presigned GetCallerIdentity call expires every 15 minutes.
+        self._update_gci_if_needed()
 
         channel = grpc.insecure_channel(self.server_address)
         stub = authenticator_pb2_grpc.AuthenticatorStub(channel)
@@ -54,8 +65,8 @@ class AuthClient(object):
         request.client_language = authenticator_pb2.PYTHON
         request.awsauth.CopyFrom(
             authenticator_pb2.AWSAuth(
-                signed_get_caller_identity=signed_gci,
-                claimed_iam_arn=claimed_arn,
+                signed_get_caller_identity=self.signed_gci,
+                claimed_iam_arn=self.claimed_arn,
             )
         )
         response = getattr(stub, getmethodname)(request)
@@ -89,3 +100,17 @@ class AuthClient(object):
             client_final = auth.create_client_final_message(response.cproof)
             auth.server_signature = response.sproof
             return client_final, auth
+
+    # The presigned GetCallerIdentity string expires every 15 minuts, so refresh it
+    # after 5 minutes just to be safe.
+    def _update_gci_if_needed(self):
+        if datetime.utcnow() - self.signed_gci_last_updated < timedelta(minutes = 5):
+            return
+        if self.iam_role is None:
+            self.signed_gci = obtain_signed_get_caller_identity(None)
+            self.signed_gci_last_updated = datetime.utcnow()
+        else:
+            response = assume_role(self.iam_role)
+            credentials = obtain_credentials(response)
+            self.signed_gci = obtain_signed_get_caller_identity(credentials)
+            self.signed_gci_last_updated = datetime.utcnow()

--- a/sdk/python/approzium/iam.py
+++ b/sdk/python/approzium/iam.py
@@ -1,5 +1,4 @@
 import boto3
-import urllib.request
 
 
 def assume_role(iam_role):

--- a/sdk/python/approzium/iam.py
+++ b/sdk/python/approzium/iam.py
@@ -1,9 +1,8 @@
 import boto3
+import urllib.request
 
 
 def assume_role(iam_role):
-    if iam_role is None:
-        raise NotImplementedError("Automatic IAM ARN determination is not implemented")
     sts_client = boto3.client("sts")
     response = sts_client.assume_role(
         DurationSeconds=3600, RoleArn=iam_role, RoleSessionName="Service1",
@@ -19,12 +18,22 @@ def obtain_claimed_arn(response):
     return response["AssumedRoleUser"]["Arn"]
 
 
-def obtain_signed_get_caller_identity(credentials):
-    iam_session = boto3.Session(
-        aws_access_key_id=credentials["AccessKeyId"],
-        aws_secret_access_key=credentials["SecretAccessKey"],
-        aws_session_token=credentials["SessionToken"],
-    )
-    iam_client = iam_session.client("sts")
-    presigned_url = iam_client.generate_presigned_url("get_caller_identity", {})
+def obtain_signed_get_caller_identity(credentials=None):
+    if credentials is None:
+        # Attempt to use local identity through the boto3 client.
+        sts_client = boto3.client('sts')
+    else:
+        sts_session = boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
+        sts_client = sts_session.client("sts")
+    presigned_url = sts_client.generate_presigned_url("get_caller_identity", {})
     return presigned_url
+
+
+def get_local_arn():
+    sts_client = boto3.client('sts')
+    response = sts_client.get_caller_identity()
+    return response["Arn"]

--- a/sdk/python/approzium/iam.py
+++ b/sdk/python/approzium/iam.py
@@ -20,7 +20,7 @@ def obtain_claimed_arn(response):
 def obtain_signed_get_caller_identity(credentials=None):
     if credentials is None:
         # Attempt to use local identity through the boto3 client.
-        sts_client = boto3.client('sts')
+        sts_client = boto3.client("sts")
     else:
         sts_session = boto3.Session(
             aws_access_key_id=credentials["AccessKeyId"],
@@ -33,6 +33,6 @@ def obtain_signed_get_caller_identity(credentials=None):
 
 
 def get_local_arn():
-    sts_client = boto3.client('sts')
+    sts_client = boto3.client("sts")
     response = sts_client.get_caller_identity()
     return response["Arn"]


### PR DESCRIPTION
Previously, if a `TEST_IAM_ARN` wasn't provided, we failed. This PR adds support for not providing one.

If a test ARN isn't provided, we will now execute one `GetCallerIdentity` on our side to learn our ARN locally to populate the `claimed_arn`. We will also construct a signed `GetCallerIdentity` request to pass on to the Go `Authenticator`. 

When I test this locally, it results in my personal user ARN being detected by the `boto3` library and passed on to the `Authenticator`. It pulls credentials as documented [here](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html).