### PR TITLE
Support config through env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ To drop into a Bash shell into the development environment, run `make dev`. This
 - Ensure you have the latest authenticator binary: `$ cd authenticator && GOOS=linux GOARCH=amd64 go build && cd ..`.
 - In your local environment, run `$ aws configure` and add an access key and secret.
   - Make sure the access key and secret you configure can assume at least one role.
+- Run `$ make dc-build`.
 - In one window, `$ docker-compose up`.
-- In another window, `$ make dev`
+- In another window, `$ make dev`.
 - Export an environment variable for the role you're testing with: `$ export TEST_IAM_ROLE=arn:aws:iam::123456789012:role/AssumableRole`.
 - To use our Python SDK to shoot a request at the authenticator, run
   `$ PGHOST=dbmd5 PGUSER=bob PGDATABASE=db python3 sdk/python/examples/pg2_client.py`.

--- a/authenticator/go.mod
+++ b/authenticator/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.3.3
 	github.com/google/gofuzz v1.1.0
 	github.com/hashicorp/vault/api v1.0.4
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/sirupsen/logrus v1.6.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	google.golang.org/grpc v1.29.1

--- a/authenticator/go.sum
+++ b/authenticator/go.sum
@@ -64,6 +64,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/authenticator/main.go
+++ b/authenticator/main.go
@@ -1,29 +1,66 @@
 package main
 
 import (
+	"fmt"
+	"net"
+	"strings"
+
 	pb "github.com/approzium/approzium/authenticator/protos"
+	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"net"
 )
 
-const (
-	serviceAddress = ":1234"
-)
+// Config is an object for storing configuration variables set through
+// Approzium's environment. Supports:
+// 		- APPROZIUM_HOST: Defaults to 127.0.0.1.
+//		- APPROZIUM_PORT: Defaults to 6000.
+//		- APPROZIUM_LOG_LEVEL: Defaults to info. Valid values are:
+//			- trace
+//			- debug
+//			- info
+//			- warn
+//			- error
+//			- fatal
+//			- panic
+//
+// For those using Vault for storage, Approzium will read Vault's address
+// and the Vault token it should use through Vault's normal environment
+// variables described here:
+// https://www.vaultproject.io/docs/commands#environment-variables.
+// At a minimum, VAULT_ADDR and VAULT_TOKEN must be set.
+type Config struct {
+	Host     string `default:"127.0.0.1"`
+	Port     int    `default:"6000"`
+	LogLevel string `envconfig:"log_level" default:"info"`
+}
 
 func main() {
-	log.SetLevel(log.DebugLevel)
+	config, err := parseConfig()
+	if err != nil {
+		log.Panicf("couldn't parse config: %s", err)
+	}
+
+	logLevel, err := log.ParseLevel(strings.ToLower(config.LogLevel))
+	if err != nil {
+		log.Panicf("couldn't parse log level: %s", err)
+	}
+	log.SetLevel(logLevel)
 	log.SetFormatter(&log.TextFormatter{
-		FullTimestamp: true,
+		FullTimestamp:          true,
+		DisableLevelTruncation: true,
+		PadLevelText:           true,
 	})
+
 	authenticator, err := NewAuthenticator()
 	if err != nil {
 		log.Panicf("failed to create authenticator: %s", err)
 	}
 
+	serviceAddress := fmt.Sprintf("%s:%d", config.Host, config.Port)
 	lis, err := net.Listen("tcp", serviceAddress)
 	if err != nil {
-		log.Panicf("failed to listen on %s", serviceAddress)
+		log.Panicf("failed to listen on %s: %s", serviceAddress, err)
 	}
 	log.Infof("authenticator listening for requests on %s\n", serviceAddress)
 
@@ -34,4 +71,14 @@ func main() {
 	if err := grpcServer.Serve(lis); err != nil {
 		log.Panicf("failed to listen on %s", serviceAddress)
 	}
+}
+
+// parseConfig returns the parsed config. A pointer is not returned
+// because after first parse, the config is immutable.
+func parseConfig() (Config, error) {
+	var config Config
+	if err := envconfig.Process("approzium", &config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
 }

--- a/authenticator/main_test.go
+++ b/authenticator/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	os.Unsetenv("APPROZIUM_HOST")
+	os.Unsetenv("APPROZIUM_PORT")
+	os.Unsetenv("APPROZIUM_LOG_LEVEL")
+	config, err := parseConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Host != "127.0.0.1" {
+		t.Fatalf("expected %s, received %s", "127.0.0.1", config.Host)
+	}
+	if config.Port != 6000 {
+		t.Fatalf("expected %d, received %d", 6000, config.Port)
+	}
+	if config.LogLevel != "info" {
+		t.Fatalf("expected %s, received %s", "info", config.LogLevel)
+	}
+
+	os.Setenv("APPROZIUM_HOST", "0.0.0.0")
+	os.Setenv("APPROZIUM_PORT", "6001")
+	os.Setenv("APPROZIUM_LOG_LEVEL", "debug")
+	config, err = parseConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Host != "0.0.0.0" {
+		t.Fatalf("expected %s, received %s", "0.0.0.0", config.Host)
+	}
+	if config.Port != 6001 {
+		t.Fatalf("expected %d, received %d", 6001, config.Port)
+	}
+	if config.LogLevel != "debug" {
+		t.Fatalf("expected %s, received %s", "debug", config.LogLevel)
+	}
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,6 +11,7 @@ services:
         working_dir: /usr/src/approzium/
         command: make run-testsuite
         environment:
+            - APPROZIUM_HOST=0.0.0.0
             - VAULT_ADDR=http://vault:8200
             - VAULT_TOKEN=root
             - AWS_ACCESS_KEY_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
             context: ./
             target: build
         environment:
+            - APPROZIUM_HOST=0.0.0.0
             - VAULT_ADDR=http://vault:8200
             - VAULT_TOKEN=root
         depends_on:

--- a/docs/src/pages/api-docs/python-sdk.mdx
+++ b/docs/src/pages/api-docs/python-sdk.mdx
@@ -16,7 +16,7 @@ _class_ **`authenticator`**
 ```python
 from approzium import Authenticator
 
-auth = Authenticator('authenticator:1234') 
+auth = Authenticator('authenticator:6000')
 # this authenticator object can be used later in the connect() method
 ```
 **`set_default_authenticator`**(new_authenticator)  
@@ -37,7 +37,7 @@ from approzium import Authenticator
 from approzium.psycopg2 import connect
 
 # create an Authenticator client
-auth = Authenticator('authenticator:1234')
+auth = Authenticator('authenticator:6000')
 
 # connect using Approzium's connect method
 conn = connect("", authenticator=auth)

--- a/docs/src/pages/examples.mdx
+++ b/docs/src/pages/examples.mdx
@@ -12,7 +12,7 @@ from approzium import Authenticator
 from approzium.psycopg2 import connect
 
 # create an Authenticator client
-auth = Authenticator('authenticator:1234')
+auth = Authenticator('authenticator:6000')
 
 # connect using Approzium's connect method
 conn = connect("", authenticator=auth)

--- a/docs/src/pages/overview.mdx
+++ b/docs/src/pages/overview.mdx
@@ -19,7 +19,7 @@ Here's what it would look like with Approzium. 😎
 from approzium import Authenticator
 from approzium.psycopg2 import connect
 
-auth = Authenticator('authenticator:1234')
+auth = Authenticator('authenticator:6000')
 
 # Look ma, no password!
 conn = connect("host=1.2.3.4 user=user1 dbname=mydb", authenticator=auth)

--- a/docs/src/pages/quickstart_.mdx
+++ b/docs/src/pages/quickstart_.mdx
@@ -53,7 +53,7 @@ from approzium import Authenticator
 from approzium.psycopg2 import connect
 
 # create an Authenticator client
-auth = Authenticator('authenticator:1234')
+auth = Authenticator('authenticator:6000')
 
 # connect using Approzium's connect method without providing a password
 conn = connect("host=1.2.3.4 user=user1 dbname=mydb", authenticator=auth)
@@ -62,3 +62,16 @@ conn = connect("host=1.2.3.4 user=user1 dbname=mydb", authenticator=auth)
 cur = conn.cursor()
 cur.execute('SELECT 1')
 ```
+
+## Configuration
+
+Approzium is configured through environment variables.
+
+- `APPROZIUM_HOST`: Defaults to `"127.0.0.1"`.
+- `APPROZIUM_PORT`: Defaults to `"6000"`.
+- `APPROZIUM_LOG_LEVEL`: Defaults to `"info"`. Supported selections are `"trace"`, `"debug"`,
+    `"info"`, `"warn"`, `"error"`, `"fatal"`, and `"panic"`. Upper case may be used.
+
+Approzium supports Vault as for storing credentials. To use Vault, at a minimum, the `VAULT_ADDR`
+and `VAULT_TOKEN` must be set. Additional Vault configuration is supported, as described
+[here](https://www.vaultproject.io/docs/commands#environment-variables).

--- a/sdk/python/examples/asyncpg_client.py
+++ b/sdk/python/examples/asyncpg_client.py
@@ -4,7 +4,7 @@ from os import environ
 from approzium import Authenticator
 from approzium.asyncpg import connect
 
-auth = Authenticator("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
+auth = Authenticator("authenticator:6000", iam_role=environ.get("TEST_IAM_ROLE"))
 
 
 async def run():

--- a/sdk/python/examples/asyncpg_pool.py
+++ b/sdk/python/examples/asyncpg_pool.py
@@ -4,7 +4,7 @@ from os import environ
 from approzium import Authenticator
 from approzium.asyncpg.pool import create_pool
 
-auth = Authenticator("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
+auth = Authenticator("authenticator:6000", iam_role=environ.get("TEST_IAM_ROLE"))
 
 
 async def run():

--- a/sdk/python/examples/pg2_client.py
+++ b/sdk/python/examples/pg2_client.py
@@ -3,7 +3,7 @@ from os import environ
 import approzium
 from approzium.psycopg2 import connect
 
-auth = approzium.AuthClient("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
+auth = approzium.AuthClient("authenticator:6000", iam_role=environ.get("TEST_IAM_ROLE"))
 approzium.default_auth_client = auth
 conn = connect("")  # or connect("", authenticator=auth)
 print("Connection Established")

--- a/sdk/python/examples/pg2_pool.py
+++ b/sdk/python/examples/pg2_pool.py
@@ -3,7 +3,7 @@ from os import environ
 from approzium import Authenticator
 from approzium.psycopg2.pool import ThreadedConnectionPool
 
-auth = Authenticator("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
+auth = Authenticator("authenticator:6000", iam_role=environ.get("TEST_IAM_ROLE"))
 conns = ThreadedConnectionPool(1, 5, "", authenticator=auth)
 conn = conns.getconn()
 print("Connection Established")

--- a/sdk/python/tests/run_pg2_testsuite.py
+++ b/sdk/python/tests/run_pg2_testsuite.py
@@ -25,7 +25,7 @@ except KeyError:
     print("Please set env var 'TEST_IAM_ROLE' to a valid value")
     sys.exit(1)
 
-auth = Authenticator("authenticator:1234", test_iam_role)
+auth = Authenticator("authenticator:6000", test_iam_role)
 set_default_authenticator(auth)
 
 # replace connect method

--- a/sdk/python/tests/test_asyncpg_connect.py
+++ b/sdk/python/tests/test_asyncpg_connect.py
@@ -5,7 +5,7 @@ import pytest
 from approzium.asyncpg import connect
 from approzium.asyncpg.pool import create_pool
 
-auth = approzium.AuthClient("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
+auth = approzium.AuthClient("authenticator:6000", iam_role=environ.get("TEST_IAM_ROLE"))
 # use Psycopg2 defined test environment variables
 connopts = {
     "user": environ["PSYCOPG2_TESTDB_USER"],

--- a/sdk/python/tests/test_psycopg2_connect.py
+++ b/sdk/python/tests/test_psycopg2_connect.py
@@ -7,7 +7,7 @@ import pytest
 from approzium.psycopg2 import connect
 from approzium.psycopg2.pool import SimpleConnectionPool, ThreadedConnectionPool
 
-auth = approzium.AuthClient("authenticator:1234", iam_role=environ.get("TEST_IAM_ROLE"))
+auth = approzium.AuthClient("authenticator:6000", iam_role=environ.get("TEST_IAM_ROLE"))
 # use Psycopg2 defined test environment variables
 connopts = {
     "user": environ["PSYCOPG2_TESTDB_USER"],


### PR DESCRIPTION
This PR adds support for configuring the local address, local port, and log level through environment variables.

I thought about adding Vault configuration at this level too, but I didn't because there are multiple, and they may change over time. Instead, I documented what's needed.

This PR also slightly changes how the logs look from:

<img width="853" alt="Screen Shot 2020-06-25 at 2 41 43 PM" src="https://user-images.githubusercontent.com/1152361/85798871-20b0fe80-b6f3-11ea-85c5-a4edf88ea988.png">

To:

<img width="883" alt="Screen Shot 2020-06-25 at 2 41 22 PM" src="https://user-images.githubusercontent.com/1152361/85798883-26a6df80-b6f3-11ea-87b9-56f67b191a67.png">

This was based on personal preference and what I've seen elsewhere. However, I'm quite flexible on this and can change it back if desired. :-)