### PR TITLE
Include AWS platforms in docs

### DIFF
--- a/docs/src/pages/languages/python.mdx
+++ b/docs/src/pages/languages/python.mdx
@@ -11,7 +11,7 @@ Our Python SDK is designed to pull identity from your local environment. It curr
 
   - Pulling an assumed role ARN from AWS EC2 instances that have been launched into a role.
   - Pulling an assumed role ARN from AWS Lambda functions that have been launched into an execution role.
-  - Pulling a role arn from a local development environment where `$ aws configure` has been run.
+  - Pulling a role arn from a local development environment where "`$ aws configure`" has been run.
 
 It uses the well-known `boto3` library for pulling identity, and thus its behavior for parsing identity
 is exactly the same.

--- a/docs/src/pages/languages/python.mdx
+++ b/docs/src/pages/languages/python.mdx
@@ -7,9 +7,14 @@ edit: false
 
 # Python SDK
 
-## Quick Start
+Our Python SDK is designed to pull identity from your local environment. It currently supports:
 
-This guide gets you started with Approzium in Python with a simple working example.
+  - Pulling an assumed role ARN from AWS EC2 instances that have been launched into a role.
+  - Pulling an assumed role ARN from AWS Lambda functions that have been launched into an execution role.
+  - Pulling a role arn from a local development environment where `$ aws configure` has been run.
+
+It uses the well-known `boto3` library for pulling identity, and thus its behavior for parsing identity
+is exactly the same.
 
 ## API
 

--- a/docs/src/pages/overview.mdx
+++ b/docs/src/pages/overview.mdx
@@ -5,7 +5,8 @@ edit: false
 ---
 
 # Approzium
-**Approzium** enables services to securely connect to databases without providing credentials.
+**Approzium** enables services to securely connect to databases without providing credentials. Passwords don't even live
+in your client's memory, so your client can't leak them!
 
 Here's how you might typically connect to your database.
 ```python

--- a/docs/src/pages/quickstart_.mdx
+++ b/docs/src/pages/quickstart_.mdx
@@ -5,29 +5,37 @@ route: /quickstart
 ---
 
 # Quickstart
-This guide will show you how to
-- deploy Authenticator
-- store database credentials in Vault to be retrieved by authenticator
-- connect to a postgres database through Approzium Python SDK
+This guide will show you how to:
+- Deploy the Authenticator.
+- Store database credentials in Vault to be retrieved by the Authenticator.
+- Connect to a Postgres database through the Approzium Python SDK.
 
-## Deploying Authenticator
-Get the Authenticator binary [here](https://github.com/approzium/approzium/tree/develop/authenticator), then run it with the environment variables `VAULT_ADDR` and `VAULT_TOKEN` set.
+## Deploying the Authenticator
+Get the Authenticator binary [here](https://github.com/approzium/approzium/tree/develop/authenticator), then run it with
+the environment variables `VAULT_ADDR` and `VAULT_TOKEN` set. These are example values, in real life we'd expect Vault to
+be run elsewhere.
 ```shell
 export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=root
 ./authenticator
 ```
 
+For availability, we recommend running the Authenticator in a long-running environment (such as an EC2 instance) rather
+than in a short-lived environment (like in AWS Lambda).
+
 ### Storing Credentials in Vault
-The Authenticator expects credentials for a single database user as a secret stored against the database user as the key. The secret contains the database password and a set of IAM roles allowed to access the credentials in the following structure.
+The Authenticator expects credentials for a single database user as a secret stored against the database user as the key.
+The secret contains the database password and a set of IAM roles allowed to access the credentials in the following structure.
 ```shell
 cat dbuser1-creds.json
 {
-    "password": "asdfghjkl",
-    "iam_arns": [
-        "arn:aws:iam::accountid:role/rolename1",
-        "arn:aws:iam::accountid:role/rolename2"
-    ]
+    "dbuser1": {
+        "password": "asdfghjkl",
+        "iam_arns": [
+            "arn:aws:iam::accountid:role/rolename1",
+            "arn:aws:iam::accountid:role/rolename2"
+        ]
+    }
 }
 ```
 
@@ -41,11 +49,11 @@ vault secrets enable -path=approzium -version=1 kv
 
 Put the secret at path `approzium/<DATABASE_HOST:DATABASE_PORT>` with your database user as the key.
 ```shell
-vault write approzium/1.2.3.4:5432 dbuser1=@dbuser1-creds.json
+vault write approzium/1.2.3.4:5432 @dbuser1-creds.json
 ```
 
 ## SDK Usage
-Install the SDK
+Install the SDK in your client.
 ```shell
 pip install approzium
 ```
@@ -59,7 +67,7 @@ from approzium.psycopg2 import connect
 auth = Authenticator('authenticator:6000')
 
 # connect using Approzium's connect method without providing a password
-conn = connect("host=1.2.3.4 user=user1 dbname=mydb", authenticator=auth)
+conn = connect("host=1.2.3.4 user=dbuser1 dbname=mydb", authenticator=auth)
 
 # use the connection cas you typically would. very cool!
 cur = conn.cursor()

--- a/docs/src/pages/quickstart_.mdx
+++ b/docs/src/pages/quickstart_.mdx
@@ -31,6 +31,9 @@ cat dbuser1-creds.json
 }
 ```
 
+For database access to be granted to a caller, the caller's exact `iam_arn` must be listed, _unless_ the caller has assumed a role.
+For assumed roles, either the role ARN or the assumed role ARN may be used to grant access.
+
 Enable Vault KV Version 1 (see [Vault documentation](https://www.vaultproject.io/docs/secrets/kv/kv-v1) for more information).
 ```shell
 vault secrets enable -path=approzium -version=1 kv


### PR DESCRIPTION
Closes #15 

This PR documents the AWS environments the Python client is confirmed to work in. 

It also updates the Vault docs, and elaborates on granting access through `iam_arns`.