### PR TITLE
Add support for using a Vault token sink file

### DIFF
--- a/authenticator/main.go
+++ b/authenticator/main.go
@@ -28,7 +28,7 @@ func main() {
 		PadLevelText:           true,
 	})
 
-	svr, err := server.New()
+	svr, err := server.New(config)
 	if err != nil {
 		log.Panicf("failed to create authenticator: %s", err)
 	}

--- a/authenticator/server/authenticator.go
+++ b/authenticator/server/authenticator.go
@@ -78,8 +78,8 @@ type Authenticator struct {
 	requestCount   int
 }
 
-func New() (*Authenticator, error) {
-	credMgr, err := credmgrs.RetrieveConfigured()
+func New(config Config) (*Authenticator, error) {
+	credMgr, err := credmgrs.RetrieveConfigured(config.VaultTokenPath)
 	if err != nil {
 		return nil, err
 	}

--- a/authenticator/server/authenticator_test.go
+++ b/authenticator/server/authenticator_test.go
@@ -32,7 +32,7 @@ func TestAuthenticator_GetPGMD5Hash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authenticator, err := New()
+	authenticator, err := New(Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestAuthenticator_GetPGSHA256Hash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authenticator, err := New()
+	authenticator, err := New(Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func TestNoRaces(t *testing.T) {
 	claimedARN := testEnv.ClaimedArn()
 
 	// Create and start the authenticator as we normally would.
-	authenticator, err := New()
+	authenticator, err := New(Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +343,7 @@ func TestFuzzAuthenticator(t *testing.T) {
 	// avoid them drowning out other tests.
 	log.SetLevel(log.FatalLevel)
 
-	authenticator, err := New()
+	authenticator, err := New(Config{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/authenticator/server/config.go
+++ b/authenticator/server/config.go
@@ -21,9 +21,10 @@ import "github.com/kelseyhightower/envconfig"
 // https://www.vaultproject.io/docs/commands#environment-variables.
 // At a minimum, VAULT_ADDR and VAULT_TOKEN must be set.
 type Config struct {
-	Host     string `default:"127.0.0.1"`
-	Port     int    `default:"6000"`
-	LogLevel string `envconfig:"log_level" default:"info"`
+	Host           string `default:"127.0.0.1"`
+	Port           int    `default:"6000"`
+	LogLevel       string `envconfig:"log_level" default:"info"`
+	VaultTokenPath string `envconfig:"vault_token_path"`
 }
 
 // ParseConfig returns the parsed config. A pointer is not returned

--- a/authenticator/server/credmgrs/credmgr.go
+++ b/authenticator/server/credmgrs/credmgr.go
@@ -35,8 +35,8 @@ type CredentialManager interface {
 
 // RetrieveConfigured checks the environment for configured cred
 // providers, and selects the first working configuration.
-func RetrieveConfigured() (CredentialManager, error) {
-	credMgr, err := newHashiCorpVaultCreds()
+func RetrieveConfigured(vaultTokenPath string) (CredentialManager, error) {
+	credMgr, err := newHashiCorpVaultCreds(vaultTokenPath)
 	if err != nil {
 		log.Debugf("didn't select HashiCorp Vault as credential manager due to err: %s", err)
 	} else {

--- a/authenticator/server/credmgrs/hc_vault_test.go
+++ b/authenticator/server/credmgrs/hc_vault_test.go
@@ -1,19 +1,95 @@
 package credmgrs
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
 	vault "github.com/hashicorp/vault/api"
 )
 
-// To run this test, first start Vault locally like so:
+// To run these tests, first start Vault locally like so:
 // "$ vault server -dev -dev-root-token-id=root"
 //
 // Then, in this application's environment, set:
 // 		VAULT_ADDR=http://localhost:8200
 // 		VAULT_TOKEN=root
-func TestHcVaultCredMgr_Password(t *testing.T) {
+func TestHcVaultCredMgr_WithTokenPath(t *testing.T) {
+	// Ensure we have the necessary test environment.
+	addr := os.Getenv(vault.EnvVaultAddress)
+	if addr == "" {
+		t.Skip("skipping because VAULT_ADDR is unset")
+	}
+
+	// Record the original
+	currentToken := os.Getenv(vault.EnvVaultToken)
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "approzium-testing-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	text := []byte(currentToken)
+	if _, err = tmpFile.Write(text); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant the necessary secrets for this test.
+	client, err := vault.NewClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We'll try mounting the secrets engine we need, but it might already be
+	// mounted, so if there's an error mounting it we'll just ignore it.
+	_, _ = client.Logical().Write("/sys/mounts/"+mountPath, map[string]interface{}{
+		"type": "kv",
+		"options": map[string]interface{}{
+			"version": "1",
+		},
+	})
+	if _, err := client.Logical().Write("approzium/127.0.0.1:5432", map[string]interface{}{
+		"dbuser1": map[string]interface{}{
+			"password": "asdfghjkl",
+			"iam_arns": []string{
+				"arn:aws:iam::accountid:role/rolename1",
+				"arn:aws:iam::accountid:role/rolename2",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unset the environmental Vault token so it must be pulled through the token sink.
+	defer func() {
+		os.Setenv(vault.EnvVaultToken, currentToken)
+	}()
+	os.Unsetenv(vault.EnvVaultToken)
+
+	// Try to read the creds through the cred manager.
+	credMgr, err := newHashiCorpVaultCreds(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := DBKey{
+		IAMArn: "arn:aws:iam::accountid:role/rolename2",
+		DBHost: "127.0.0.1",
+		DBPort: "5432",
+		DBUser: "dbuser1",
+	}
+	password, err := credMgr.Password(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if password != "asdfghjkl" {
+		t.Fatalf("expected: %s; actual: %s", "asdfghjkl", password)
+	}
+}
+
+func TestHcVaultCredMgr_WithoutTokenPath(t *testing.T) {
 	// Ensure we have the necessary test environment.
 	addr := os.Getenv(vault.EnvVaultAddress)
 	if addr == "" {
@@ -46,7 +122,7 @@ func TestHcVaultCredMgr_Password(t *testing.T) {
 	}
 
 	// Try to read the creds through the cred manager.
-	credMgr, err := newHashiCorpVaultCreds()
+	credMgr, err := newHashiCorpVaultCreds("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/src/pages/quickstart_.mdx
+++ b/docs/src/pages/quickstart_.mdx
@@ -82,7 +82,11 @@ Approzium is configured through environment variables.
 - `APPROZIUM_PORT`: Defaults to `"6000"`.
 - `APPROZIUM_LOG_LEVEL`: Defaults to `"info"`. Supported selections are `"trace"`, `"debug"`,
     `"info"`, `"warn"`, `"error"`, `"fatal"`, and `"panic"`. Upper case may be used.
+- `APPROZIUM_VAULT_TOKEN_PATH`: Optional, if set it will cause the latest Vault token to always
+    be pulled from the given file. See more on using this option
+    [here](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-aws).
 
 Approzium supports Vault as for storing credentials. To use Vault, at a minimum, the `VAULT_ADDR`
-and `VAULT_TOKEN` must be set. Additional Vault configuration is supported, as described
+must be set. Either the `VAULT_TOKEN` or `APPROZIUM_VAULT_TOKEN_PATH` must be set, with the `VAULT_TOKEN`
+taking precedence. Additional Vault configuration is supported, as described
 [here](https://www.vaultproject.io/docs/commands#environment-variables).


### PR DESCRIPTION
This PR adds support for pulling a Vault token from a file. This will prevent its Vault access from expiring when the original `VAULT_TOKEN` pulled at startup expires.

The Vault agent pushes tokens out to file and always keeps them updated. It can be used with a variety of platforms, not just AWS, so this will be forward-compatible with the other ones we add as well.