### PR TITLE
Add JSON attribution_info to authenticator

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,3 +24,5 @@ python-docs:
 	cd ../sdk/python/ && poetry run make -C docs/ html
 	mkdir -p static/api
 	cp -r ../sdk/python/docs/build/html static/api/python
+
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,5 +24,3 @@ python-docs:
 	cd ../sdk/python/ && poetry run make -C docs/ html
 	mkdir -p static/api
 	cp -r ../sdk/python/docs/build/html static/api/python
-
-

--- a/sdk/python/approzium/_authenticator.py
+++ b/sdk/python/approzium/_authenticator.py
@@ -83,6 +83,11 @@ class AuthClient(object):
 
     @property
     def attribution_info_json(self):
+        """Provides the same attribution info returned by
+        :func:`~AuthClient.attribution_info` as a JSON format string
+
+        :rtype: str
+        """
         info = self.attribution_info
         return json.dumps(info)
 

--- a/sdk/python/approzium/_authenticator.py
+++ b/sdk/python/approzium/_authenticator.py
@@ -40,7 +40,6 @@ class AuthClient(object):
         self.authenticated = False
         self._counter = count(1)
         self.n_conns = 0
-        self.iam_role = iam_role
 
         # Parse the claimed ARN once because it'll never change.
         # Parse the signed_gci at startup, and then we'll update
@@ -75,7 +74,7 @@ class AuthClient(object):
         """
         info = {}
         info["authenticator_address"] = self.server_address
-        info["iam_role"] = self.iam_role
+        info["iam_arn"] = self.claimed_arn
         info["authenticated"] = self.authenticated
         info["num_connections"] = self.n_conns
         return info

--- a/sdk/python/approzium/_authenticator.py
+++ b/sdk/python/approzium/_authenticator.py
@@ -67,7 +67,7 @@ class AuthClient(object):
 
         **Return Structure**:
             * *authenticator_address* (*str*): address of authenticator service used
-            * *iam_role* (*str*): IAM Amazon resource number (ARN) used as identity
+            * *iam_arn* (*str*): IAM Amazon resource number (ARN) used as identity
             * *authenticated* (*bool*): whether the AuthClient was verified by the
                                         authenticator service.
             * *num_connections* (*int*): number of connections made through this

--- a/sdk/python/approzium/_authenticator.py
+++ b/sdk/python/approzium/_authenticator.py
@@ -1,5 +1,6 @@
 # needed to be able to import protos code
 import sys
+import json
 from datetime import datetime, timedelta
 from itertools import count
 from pathlib import Path
@@ -78,6 +79,12 @@ class AuthClient(object):
         info["authenticated"] = self.authenticated
         info["num_connections"] = self.n_conns
         return info
+
+
+    @property
+    def attribution_info_json(self):
+        info = self.attribution_info
+        return json.dumps(info)
 
     def _execute_request(self, request, getmethodname):
         # The presigned GetCallerIdentity call expires every 15 minutes.


### PR DESCRIPTION
In addition to title, fixed a tiny bug where if the IAM arn is automatically determined, it is not shown in `attribution_info`