### PR TITLE
Fix flaky test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ seed-vault-all-hosts:
 run-testsuite: run-gotests run-pg2tests
 
 run-gotests:
-	cd authenticator && CGO_ENABLED=1 go test -v -race ./...
+	cd authenticator && CGO_ENABLED=1 go test -v -race -p 1 ./...
 
 run-pythontests: enable-vault-path seed-vault-all-hosts
 	cd sdk/python && poetry run pytest --workers auto


### PR DESCRIPTION
This fixes the flaky test failure we've been seeing:

```
=== RUN TestFuzzAuthenticator 
race: limit on 8128 simultaneously alive goroutines is exceeded, dying 
FAIL	github.com/approzium/approzium/authenticator/server	15.740s
```

None of the tests by themselves have more than 2,000 goroutines going at once. However, by default, Go runs tests in parallel. So, the reason we're seeing this failure is that when the tests are run in parallel, they can at times have that many goroutines going.

This PR solves that by setting the Go test parallelism to 1, which prevents that many goroutines from going at once. I've run the tests remotely 10 times and haven't seen the problem again.