### PR TITLE
Fix isort change in Github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install Python lint libraries
         run: |
-          pip install isort black flake8
+          pip install isort==5.0.2 black==19.10b0 flake8==3.8.3
 
       - run: cd sdk/python && isort .
       - run: cd sdk/python && black .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           pip install isort black flake8
 
-      - run: cd sdk/python && isort -y .
+      - run: cd sdk/python && isort .
       - run: cd sdk/python && black .
       - run: cd sdk/python && flake8
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           pip install isort black flake8
 
-      - run: cd sdk/python && isort -y --recursive
+      - run: cd sdk/python && isort -y .
       - run: cd sdk/python && black .
       - run: cd sdk/python && flake8
 

--- a/sdk/python/approzium/asyncpg/_asyncpg_connect.py
+++ b/sdk/python/approzium/asyncpg/_asyncpg_connect.py
@@ -1,9 +1,10 @@
 import logging
 
-import approzium
 import asyncpg
 from asyncpg.connect_utils import _ConnectionParameters
 from asyncpg.protocol import Protocol
+
+import approzium
 
 from .._postgres import PGAuthClient, construct_msg, parse_msg
 

--- a/sdk/python/approzium/psycopg2/_psycopg2_connect.py
+++ b/sdk/python/approzium/psycopg2/_psycopg2_connect.py
@@ -1,8 +1,9 @@
 import logging
 import select
 
-import approzium
 import psycopg2
+
+import approzium
 
 from .._postgres import PGAuthClient
 from ._psycopg2_ctypes import (

--- a/sdk/python/tests/run_pg2_testsuite.py
+++ b/sdk/python/tests/run_pg2_testsuite.py
@@ -11,6 +11,7 @@ from unittest import SkipTest
 
 import pg2_testsuite  # noqa: E402 F401
 import psycopg2
+
 from approzium import Authenticator, set_default_authenticator
 
 # once get hash is mocked, import connect method

--- a/sdk/python/tests/test_asyncpg_connect.py
+++ b/sdk/python/tests/test_asyncpg_connect.py
@@ -1,7 +1,8 @@
 from os import environ
 
-import approzium
 import pytest
+
+import approzium
 from approzium.asyncpg import connect
 from approzium.asyncpg.pool import create_pool
 

--- a/sdk/python/tests/test_psycopg2_connect.py
+++ b/sdk/python/tests/test_psycopg2_connect.py
@@ -1,9 +1,10 @@
 from os import environ
 from select import select
 
-import approzium
 import psycopg2
 import pytest
+
+import approzium
 from approzium.psycopg2 import connect
 from approzium.psycopg2.pool import SimpleConnectionPool, ThreadedConnectionPool
 


### PR DESCRIPTION
Looks like `isort` just had a new major release which broke the interface we use. This updates the command in our CI to stay compatible.

To avoid having these issues in the future, this PR also specifies the versions of the lint tools used, so pip will install the latest compatible patch version.