### PR TITLE
Fix running approzium.psycopg2 on OSX

### DIFF
--- a/sdk/python/approzium/psycopg2/_psycopg2_connect.py
+++ b/sdk/python/approzium/psycopg2/_psycopg2_connect.py
@@ -103,6 +103,10 @@ def connect(dsn=None, cursor_factory=None, authenticator=None, **kwargs):
         >>> auth = approzium.AuthClient("myauthenticator.com:6001")
         >>> con = connect("host=DB.com dbname=mydb", authenticator=auth)  # no password!
         >>> # use the connection just like any other Psycopg2 connection
+
+    .. warning::
+        Currently, only `psycopg2` with dynamically linked `libpq` is
+        supported. Thus, `psycopg2-binary` is not supported.
     """
     is_sync = True
     if kwargs.get("async", False):

--- a/sdk/python/approzium/psycopg2/_psycopg2_ctypes.py
+++ b/sdk/python/approzium/psycopg2/_psycopg2_ctypes.py
@@ -19,7 +19,7 @@ from .._socketfromfd import fromfd
 
 logger = logging.getLogger(__name__)
 
-libpq = cdll.LoadLibrary("libpq.so.5")
+libpq = cdll.LoadLibrary(find_library("pq"))
 libssl = cdll.LoadLibrary(find_library("ssl"))
 
 


### PR DESCRIPTION
The problem was that we told Python to find the `libpq` (the C library used by Psycopg2) by specifying its name directly as `libpq.so.5`. However, this name is only correct on Linux and could differ by OS. For example, on OSX this would be `libpq.5.dylib` and Windows uses `.dll`. The fix is to use a function that finds the library by name on whatever OS Python is running on.